### PR TITLE
Add graphql-codegen cfg and storefront API types

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+.nuxt
+dist/
+interfaces/storefront-api.ts

--- a/codegen.yml
+++ b/codegen.yml
@@ -1,0 +1,8 @@
+schema:
+  - https://graphql.myshopify.com/api/2019-10/graphql:
+      headers:
+        Authorization: Basic MzUxYzEyMjAxN2QwZjJhOTU3ZDMyYWU3MjhhZDc0OWM=
+generates:
+  ./interfaces/storefront-api.ts:
+    plugins:
+      - typescript

--- a/interfaces/storefront-api.ts
+++ b/interfaces/storefront-api.ts
@@ -1,0 +1,4319 @@
+export type Maybe<T> = T | null;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: string,
+  String: string,
+  Boolean: boolean,
+  Int: number,
+  Float: number,
+  /** 
+ * An RFC 3986 and RFC 3987 compliant URI string.
+   * 
+   * Example value: `"https://johns-apparel.myshopify.com"`.
+ **/
+  URL: any,
+  /** A string containing HTML code. Example value: `"<p>Grey cotton knit sweater.</p>"`. */
+  HTML: any,
+  /** An ISO-8601 encoded UTC date time string. Example value: `"2019-07-03T20:47:55Z"`. */
+  DateTime: any,
+  /** A monetary value string. Example value: `"100.57"`. */
+  Money: any,
+  /** A signed decimal number, which supports arbitrary precision and is serialized as a string. Example value: `"29.99"`. */
+  Decimal: any,
+};
+
+
+/** A version of the API. */
+export type ApiVersion = {
+   __typename?: 'ApiVersion',
+  /** The human-readable name of the version. */
+  displayName: Scalars['String'],
+  /** The unique identifier of an ApiVersion. All supported API versions have a date-based (YYYY-MM) or `unstable` handle. */
+  handle: Scalars['String'],
+  /** Whether the version is supported by Shopify. */
+  supported: Scalars['Boolean'],
+};
+
+/** Details about the gift card used on the checkout. */
+export type AppliedGiftCard = Node & {
+   __typename?: 'AppliedGiftCard',
+  /** The amount that was taken from the Gift Card by applying it. */
+  amountUsed: Scalars['Money'],
+  /** The amount that was taken from the Gift Card by applying it. */
+  amountUsedV2: MoneyV2,
+  /** The amount left on the Gift Card. */
+  balance: Scalars['Money'],
+  /** The amount left on the Gift Card. */
+  balanceV2: MoneyV2,
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** The last characters of the Gift Card code */
+  lastCharacters: Scalars['String'],
+  /** The amount that was applied to the checkout in its currency. */
+  presentmentAmountUsed: MoneyV2,
+};
+
+export type Article = Node & {
+   __typename?: 'Article',
+  /** The article's author. */
+  author: ArticleAuthor,
+  /** The article's author. */
+  authorV2?: Maybe<ArticleAuthor>,
+  /** The blog that the article belongs to. */
+  blog: Blog,
+  /** List of comments posted on the article. */
+  comments: CommentConnection,
+  /** Stripped content of the article, single line with HTML tags removed. */
+  content: Scalars['String'],
+  /** The content of the article, complete with HTML formatting. */
+  contentHtml: Scalars['HTML'],
+  /** Stripped excerpt of the article, single line with HTML tags removed. */
+  excerpt?: Maybe<Scalars['String']>,
+  /** The excerpt of the article, complete with HTML formatting. */
+  excerptHtml?: Maybe<Scalars['HTML']>,
+  /** A human-friendly unique string for the Article automatically generated from its title. */
+  handle: Scalars['String'],
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** The image associated with the article. */
+  image?: Maybe<Image>,
+  /** The date and time when the article was published. */
+  publishedAt: Scalars['DateTime'],
+  /** The article’s SEO information. */
+  seo?: Maybe<Seo>,
+  /** A categorization that a article can be tagged with. */
+  tags: Array<Scalars['String']>,
+  /** The article’s name. */
+  title: Scalars['String'],
+  /** The url pointing to the article accessible from the web. */
+  url: Scalars['URL'],
+};
+
+
+export type ArticleCommentsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+export type ArticleContentArgs = {
+  truncateAt?: Maybe<Scalars['Int']>
+};
+
+
+export type ArticleExcerptArgs = {
+  truncateAt?: Maybe<Scalars['Int']>
+};
+
+
+export type ArticleImageArgs = {
+  maxWidth?: Maybe<Scalars['Int']>,
+  maxHeight?: Maybe<Scalars['Int']>,
+  crop?: Maybe<CropRegion>,
+  scale?: Maybe<Scalars['Int']>
+};
+
+export type ArticleAuthor = {
+   __typename?: 'ArticleAuthor',
+  /** The author's bio. */
+  bio?: Maybe<Scalars['String']>,
+  /** The author’s email. */
+  email: Scalars['String'],
+  /** The author's first name. */
+  firstName: Scalars['String'],
+  /** The author's last name. */
+  lastName: Scalars['String'],
+  /** The author's full name. */
+  name: Scalars['String'],
+};
+
+export type ArticleConnection = {
+   __typename?: 'ArticleConnection',
+  /** A list of edges. */
+  edges: Array<ArticleEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type ArticleEdge = {
+   __typename?: 'ArticleEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of ArticleEdge. */
+  node: Article,
+};
+
+/** The set of valid sort keys for the articles query. */
+export enum ArticleSortKeys {
+  /** Sort by the `title` value. */
+  Title = 'TITLE',
+  /** Sort by the `blog_title` value. */
+  BlogTitle = 'BLOG_TITLE',
+  /** Sort by the `author` value. */
+  Author = 'AUTHOR',
+  /** Sort by the `updated_at` value. */
+  UpdatedAt = 'UPDATED_AT',
+  /** Sort by the `published_at` value. */
+  PublishedAt = 'PUBLISHED_AT',
+  /** Sort by the `id` value. */
+  Id = 'ID',
+  /** 
+ * During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the
+   * results by relevance to the search term(s). When no search query is specified, this sort key is not
+   * deterministic and should not be used.
+ **/
+  Relevance = 'RELEVANCE'
+}
+
+/** Represents a generic custom attribute. */
+export type Attribute = {
+   __typename?: 'Attribute',
+  /** Key or name of the attribute. */
+  key: Scalars['String'],
+  /** Value of the attribute. */
+  value?: Maybe<Scalars['String']>,
+};
+
+/** Specifies the input fields required for an attribute. */
+export type AttributeInput = {
+  /** Key or name of the attribute. */
+  key: Scalars['String'],
+  /** Value of the attribute. */
+  value: Scalars['String'],
+};
+
+/** Automatic discount applications capture the intentions of a discount that was automatically applied. */
+export type AutomaticDiscountApplication = DiscountApplication & {
+   __typename?: 'AutomaticDiscountApplication',
+  /** The method by which the discount's value is allocated to its entitled items. */
+  allocationMethod: DiscountApplicationAllocationMethod,
+  /** Which lines of targetType that the discount is allocated over. */
+  targetSelection: DiscountApplicationTargetSelection,
+  /** The type of line that the discount is applicable towards. */
+  targetType: DiscountApplicationTargetType,
+  /** The title of the application. */
+  title: Scalars['String'],
+  /** The value of the discount application. */
+  value: PricingValue,
+};
+
+/** A collection of available shipping rates for a checkout. */
+export type AvailableShippingRates = {
+   __typename?: 'AvailableShippingRates',
+  /** 
+ * Whether or not the shipping rates are ready.
+   * The `shippingRates` field is `null` when this value is `false`.
+   * This field should be polled until its value becomes `true`.
+ **/
+  ready: Scalars['Boolean'],
+  /** The fetched shipping rates. `null` until the `ready` field is `true`. */
+  shippingRates?: Maybe<Array<ShippingRate>>,
+};
+
+export type Blog = Node & {
+   __typename?: 'Blog',
+  /** Find an article by its handle. */
+  articleByHandle?: Maybe<Article>,
+  /** List of the blog's articles. */
+  articles: ArticleConnection,
+  /** The authors who have contributed to the blog. */
+  authors: Array<ArticleAuthor>,
+  /** A human-friendly unique string for the Blog automatically generated from its title. */
+  handle: Scalars['String'],
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** The blogs’s title. */
+  title: Scalars['String'],
+  /** The url pointing to the blog accessible from the web. */
+  url: Scalars['URL'],
+};
+
+
+export type BlogArticleByHandleArgs = {
+  handle: Scalars['String']
+};
+
+
+export type BlogArticlesArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<ArticleSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+export type BlogConnection = {
+   __typename?: 'BlogConnection',
+  /** A list of edges. */
+  edges: Array<BlogEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type BlogEdge = {
+   __typename?: 'BlogEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of BlogEdge. */
+  node: Blog,
+};
+
+/** The set of valid sort keys for the blogs query. */
+export enum BlogSortKeys {
+  /** Sort by the `handle` value. */
+  Handle = 'HANDLE',
+  /** Sort by the `title` value. */
+  Title = 'TITLE',
+  /** Sort by the `id` value. */
+  Id = 'ID',
+  /** 
+ * During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the
+   * results by relevance to the search term(s). When no search query is specified, this sort key is not
+   * deterministic and should not be used.
+ **/
+  Relevance = 'RELEVANCE'
+}
+
+/** Card brand, such as Visa or Mastercard, which can be used for payments. */
+export enum CardBrand {
+  /** Visa */
+  Visa = 'VISA',
+  /** Mastercard */
+  Mastercard = 'MASTERCARD',
+  /** Discover */
+  Discover = 'DISCOVER',
+  /** American Express */
+  AmericanExpress = 'AMERICAN_EXPRESS',
+  /** Diners Club */
+  DinersClub = 'DINERS_CLUB',
+  /** JCB */
+  Jcb = 'JCB'
+}
+
+/** A container for all the information required to checkout items and pay. */
+export type Checkout = Node & {
+   __typename?: 'Checkout',
+  appliedGiftCards: Array<AppliedGiftCard>,
+  /** 
+ * The available shipping rates for this Checkout.
+   * Should only be used when checkout `requiresShipping` is `true` and
+   * the shipping address is valid.
+ **/
+  availableShippingRates?: Maybe<AvailableShippingRates>,
+  /** The date and time when the checkout was completed. */
+  completedAt?: Maybe<Scalars['DateTime']>,
+  /** The date and time when the checkout was created. */
+  createdAt: Scalars['DateTime'],
+  /** The currency code for the Checkout. */
+  currencyCode: CurrencyCode,
+  /** A list of extra information that is added to the checkout. */
+  customAttributes: Array<Attribute>,
+  /** The customer associated with the checkout. */
+  customer?: Maybe<Customer>,
+  /** Discounts that have been applied on the checkout. */
+  discountApplications: DiscountApplicationConnection,
+  /** The email attached to this checkout. */
+  email?: Maybe<Scalars['String']>,
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** A list of line item objects, each one containing information about an item in the checkout. */
+  lineItems: CheckoutLineItemConnection,
+  /** The sum of all the prices of all the items in the checkout. Taxes, shipping and discounts excluded. */
+  lineItemsSubtotalPrice: MoneyV2,
+  note?: Maybe<Scalars['String']>,
+  /** The resulting order from a paid checkout. */
+  order?: Maybe<Order>,
+  /** The Order Status Page for this Checkout, null when checkout is not completed. */
+  orderStatusUrl?: Maybe<Scalars['URL']>,
+  /** 
+ * The amount left to be paid. This is equal to the cost of the line items, taxes
+   * and shipping minus discounts and gift cards.
+ **/
+  paymentDue: Scalars['Money'],
+  /** 
+ * The amount left to be paid. This is equal to the cost of the line items, taxes
+   * and shipping minus discounts and gift cards.
+ **/
+  paymentDueV2: MoneyV2,
+  /** 
+ * Whether or not the Checkout is ready and can be completed. Checkouts may
+   * have asynchronous operations that can take time to finish. If you want
+   * to complete a checkout or ensure all the fields are populated and up to
+   * date, polling is required until the value is true.
+ **/
+  ready: Scalars['Boolean'],
+  /** States whether or not the fulfillment requires shipping. */
+  requiresShipping: Scalars['Boolean'],
+  /** The shipping address to where the line items will be shipped. */
+  shippingAddress?: Maybe<MailingAddress>,
+  /** The discounts that have been allocated onto the shipping line by discount applications. */
+  shippingDiscountAllocations: Array<DiscountAllocation>,
+  /** Once a shipping rate is selected by the customer it is transitioned to a `shipping_line` object. */
+  shippingLine?: Maybe<ShippingRate>,
+  /** Price of the checkout before shipping and taxes. */
+  subtotalPrice: Scalars['Money'],
+  /** Price of the checkout before shipping and taxes. */
+  subtotalPriceV2: MoneyV2,
+  /** Specifies if the Checkout is tax exempt. */
+  taxExempt: Scalars['Boolean'],
+  /** Specifies if taxes are included in the line item and shipping line prices. */
+  taxesIncluded: Scalars['Boolean'],
+  /** The sum of all the prices of all the items in the checkout, taxes and discounts included. */
+  totalPrice: Scalars['Money'],
+  /** The sum of all the prices of all the items in the checkout, taxes and discounts included. */
+  totalPriceV2: MoneyV2,
+  /** The sum of all the taxes applied to the line items and shipping lines in the checkout. */
+  totalTax: Scalars['Money'],
+  /** The sum of all the taxes applied to the line items and shipping lines in the checkout. */
+  totalTaxV2: MoneyV2,
+  /** The date and time when the checkout was last updated. */
+  updatedAt: Scalars['DateTime'],
+  /** The url pointing to the checkout accessible from the web. */
+  webUrl: Scalars['URL'],
+};
+
+
+/** A container for all the information required to checkout items and pay. */
+export type CheckoutDiscountApplicationsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** A container for all the information required to checkout items and pay. */
+export type CheckoutLineItemsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+/** Specifies the fields required to update a checkout's attributes. */
+export type CheckoutAttributesUpdateInput = {
+  /** The text of an optional note that a shop owner can attach to the checkout. */
+  note?: Maybe<Scalars['String']>,
+  /** A list of extra information that is added to the checkout. */
+  customAttributes?: Maybe<Array<AttributeInput>>,
+  /** 
+ * Allows setting partial addresses on a Checkout, skipping the full validation of attributes.
+   * The required attributes are city, province, and country.
+   * Full validation of the addresses is still done at complete time.
+ **/
+  allowPartialAddresses?: Maybe<Scalars['Boolean']>,
+};
+
+/** Return type for `checkoutAttributesUpdate` mutation. */
+export type CheckoutAttributesUpdatePayload = {
+   __typename?: 'CheckoutAttributesUpdatePayload',
+  /** The updated checkout object. */
+  checkout: Checkout,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Specifies the fields required to update a checkout's attributes. */
+export type CheckoutAttributesUpdateV2Input = {
+  /** The text of an optional note that a shop owner can attach to the checkout. */
+  note?: Maybe<Scalars['String']>,
+  /** A list of extra information that is added to the checkout. */
+  customAttributes?: Maybe<Array<AttributeInput>>,
+  /** 
+ * Allows setting partial addresses on a Checkout, skipping the full validation of attributes.
+   * The required attributes are city, province, and country.
+   * Full validation of the addresses is still done at complete time.
+ **/
+  allowPartialAddresses?: Maybe<Scalars['Boolean']>,
+};
+
+/** Return type for `checkoutAttributesUpdateV2` mutation. */
+export type CheckoutAttributesUpdateV2Payload = {
+   __typename?: 'CheckoutAttributesUpdateV2Payload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutCompleteFree` mutation. */
+export type CheckoutCompleteFreePayload = {
+   __typename?: 'CheckoutCompleteFreePayload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutCompleteWithCreditCard` mutation. */
+export type CheckoutCompleteWithCreditCardPayload = {
+   __typename?: 'CheckoutCompleteWithCreditCardPayload',
+  /** The checkout on which the payment was applied. */
+  checkout: Checkout,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** A representation of the attempted payment. */
+  payment?: Maybe<Payment>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutCompleteWithCreditCardV2` mutation. */
+export type CheckoutCompleteWithCreditCardV2Payload = {
+   __typename?: 'CheckoutCompleteWithCreditCardV2Payload',
+  /** The checkout on which the payment was applied. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** A representation of the attempted payment. */
+  payment?: Maybe<Payment>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutCompleteWithTokenizedPayment` mutation. */
+export type CheckoutCompleteWithTokenizedPaymentPayload = {
+   __typename?: 'CheckoutCompleteWithTokenizedPaymentPayload',
+  /** The checkout on which the payment was applied. */
+  checkout: Checkout,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** A representation of the attempted payment. */
+  payment?: Maybe<Payment>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutCompleteWithTokenizedPaymentV2` mutation. */
+export type CheckoutCompleteWithTokenizedPaymentV2Payload = {
+   __typename?: 'CheckoutCompleteWithTokenizedPaymentV2Payload',
+  /** The checkout on which the payment was applied. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** A representation of the attempted payment. */
+  payment?: Maybe<Payment>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Specifies the fields required to create a checkout. */
+export type CheckoutCreateInput = {
+  /** The email with which the customer wants to checkout. */
+  email?: Maybe<Scalars['String']>,
+  /** A list of line item objects, each one containing information about an item in the checkout. */
+  lineItems?: Maybe<Array<CheckoutLineItemInput>>,
+  /** The shipping address to where the line items will be shipped. */
+  shippingAddress?: Maybe<MailingAddressInput>,
+  /** The text of an optional note that a shop owner can attach to the checkout. */
+  note?: Maybe<Scalars['String']>,
+  /** A list of extra information that is added to the checkout. */
+  customAttributes?: Maybe<Array<AttributeInput>>,
+  /** 
+ * Allows setting partial addresses on a Checkout, skipping the full validation of attributes.
+   * The required attributes are city, province, and country.
+   * Full validation of addresses is still done at complete time.
+ **/
+  allowPartialAddresses?: Maybe<Scalars['Boolean']>,
+  /** 
+ * The three-letter currency code of one of the shop's enabled presentment currencies.
+   * Including this field creates a checkout in the specified currency. By default, new
+   * checkouts are created in the shop's primary currency.
+ **/
+  presentmentCurrencyCode?: Maybe<CurrencyCode>,
+};
+
+/** Return type for `checkoutCreate` mutation. */
+export type CheckoutCreatePayload = {
+   __typename?: 'CheckoutCreatePayload',
+  /** The new checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutCustomerAssociate` mutation. */
+export type CheckoutCustomerAssociatePayload = {
+   __typename?: 'CheckoutCustomerAssociatePayload',
+  /** The updated checkout object. */
+  checkout: Checkout,
+  /** The associated customer object. */
+  customer?: Maybe<Customer>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutCustomerAssociateV2` mutation. */
+export type CheckoutCustomerAssociateV2Payload = {
+   __typename?: 'CheckoutCustomerAssociateV2Payload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** The associated customer object. */
+  customer?: Maybe<Customer>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutCustomerDisassociate` mutation. */
+export type CheckoutCustomerDisassociatePayload = {
+   __typename?: 'CheckoutCustomerDisassociatePayload',
+  /** The updated checkout object. */
+  checkout: Checkout,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutCustomerDisassociateV2` mutation. */
+export type CheckoutCustomerDisassociateV2Payload = {
+   __typename?: 'CheckoutCustomerDisassociateV2Payload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutDiscountCodeApply` mutation. */
+export type CheckoutDiscountCodeApplyPayload = {
+   __typename?: 'CheckoutDiscountCodeApplyPayload',
+  /** The updated checkout object. */
+  checkout: Checkout,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutDiscountCodeApplyV2` mutation. */
+export type CheckoutDiscountCodeApplyV2Payload = {
+   __typename?: 'CheckoutDiscountCodeApplyV2Payload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutDiscountCodeRemove` mutation. */
+export type CheckoutDiscountCodeRemovePayload = {
+   __typename?: 'CheckoutDiscountCodeRemovePayload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutEmailUpdate` mutation. */
+export type CheckoutEmailUpdatePayload = {
+   __typename?: 'CheckoutEmailUpdatePayload',
+  /** The checkout object with the updated email. */
+  checkout: Checkout,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutEmailUpdateV2` mutation. */
+export type CheckoutEmailUpdateV2Payload = {
+   __typename?: 'CheckoutEmailUpdateV2Payload',
+  /** The checkout object with the updated email. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Possible error codes that could be returned by a checkout mutation. */
+export enum CheckoutErrorCode {
+  /** Input value is blank. */
+  Blank = 'BLANK',
+  /** Input value is invalid. */
+  Invalid = 'INVALID',
+  /** Input value is too long. */
+  TooLong = 'TOO_LONG',
+  /** Input value is not present. */
+  Present = 'PRESENT',
+  /** Input value should be less than maximum allowed value. */
+  LessThan = 'LESS_THAN',
+  /** Input value should be greater than or equal to minimum allowed value. */
+  GreaterThanOrEqualTo = 'GREATER_THAN_OR_EQUAL_TO',
+  /** Input value should be less or equal to maximum allowed value. */
+  LessThanOrEqualTo = 'LESS_THAN_OR_EQUAL_TO',
+  /** Checkout is already completed. */
+  AlreadyCompleted = 'ALREADY_COMPLETED',
+  /** Checkout is locked. */
+  Locked = 'LOCKED',
+  /** Input value is not supported. */
+  NotSupported = 'NOT_SUPPORTED',
+  /** Input email contains an invalid domain name. */
+  BadDomain = 'BAD_DOMAIN',
+  /** Input Zip is invalid for country provided. */
+  InvalidForCountry = 'INVALID_FOR_COUNTRY',
+  /** Input Zip is invalid for country and province provided. */
+  InvalidForCountryAndProvince = 'INVALID_FOR_COUNTRY_AND_PROVINCE',
+  /** Invalid state in country. */
+  InvalidStateInCountry = 'INVALID_STATE_IN_COUNTRY',
+  /** Invalid province in country. */
+  InvalidProvinceInCountry = 'INVALID_PROVINCE_IN_COUNTRY',
+  /** Invalid region in country. */
+  InvalidRegionInCountry = 'INVALID_REGION_IN_COUNTRY',
+  /** Shipping rate expired. */
+  ShippingRateExpired = 'SHIPPING_RATE_EXPIRED',
+  /** Gift card cannot be applied to a checkout that contains a gift card. */
+  GiftCardUnusable = 'GIFT_CARD_UNUSABLE',
+  /** Gift card is disabled. */
+  GiftCardDisabled = 'GIFT_CARD_DISABLED',
+  /** Gift card code is invalid. */
+  GiftCardCodeInvalid = 'GIFT_CARD_CODE_INVALID',
+  /** Gift card has already been applied. */
+  GiftCardAlreadyApplied = 'GIFT_CARD_ALREADY_APPLIED',
+  /** Gift card currency does not match checkout currency. */
+  GiftCardCurrencyMismatch = 'GIFT_CARD_CURRENCY_MISMATCH',
+  /** Gift card is expired. */
+  GiftCardExpired = 'GIFT_CARD_EXPIRED',
+  /** Gift card has no funds left. */
+  GiftCardDepleted = 'GIFT_CARD_DEPLETED',
+  /** Gift card was not found. */
+  GiftCardNotFound = 'GIFT_CARD_NOT_FOUND',
+  /** Cart does not meet discount requirements notice. */
+  CartDoesNotMeetDiscountRequirementsNotice = 'CART_DOES_NOT_MEET_DISCOUNT_REQUIREMENTS_NOTICE',
+  /** Discount expired. */
+  DiscountExpired = 'DISCOUNT_EXPIRED',
+  /** Discount disabled. */
+  DiscountDisabled = 'DISCOUNT_DISABLED',
+  /** Discount limit reached. */
+  DiscountLimitReached = 'DISCOUNT_LIMIT_REACHED',
+  /** Discount not found. */
+  DiscountNotFound = 'DISCOUNT_NOT_FOUND',
+  /** Customer already used once per customer discount notice. */
+  CustomerAlreadyUsedOncePerCustomerDiscountNotice = 'CUSTOMER_ALREADY_USED_ONCE_PER_CUSTOMER_DISCOUNT_NOTICE',
+  /** Checkout is already completed. */
+  Empty = 'EMPTY',
+  /** Not enough in stock. */
+  NotEnoughInStock = 'NOT_ENOUGH_IN_STOCK',
+  /** Missing payment input. */
+  MissingPaymentInput = 'MISSING_PAYMENT_INPUT',
+  /** The amount of the payment does not match the value to be paid. */
+  TotalPriceMismatch = 'TOTAL_PRICE_MISMATCH',
+  /** Line item was not found in checkout. */
+  LineItemNotFound = 'LINE_ITEM_NOT_FOUND'
+}
+
+/** Return type for `checkoutGiftCardApply` mutation. */
+export type CheckoutGiftCardApplyPayload = {
+   __typename?: 'CheckoutGiftCardApplyPayload',
+  /** The updated checkout object. */
+  checkout: Checkout,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutGiftCardRemove` mutation. */
+export type CheckoutGiftCardRemovePayload = {
+   __typename?: 'CheckoutGiftCardRemovePayload',
+  /** The updated checkout object. */
+  checkout: Checkout,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutGiftCardRemoveV2` mutation. */
+export type CheckoutGiftCardRemoveV2Payload = {
+   __typename?: 'CheckoutGiftCardRemoveV2Payload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutGiftCardsAppend` mutation. */
+export type CheckoutGiftCardsAppendPayload = {
+   __typename?: 'CheckoutGiftCardsAppendPayload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** A single line item in the checkout, grouped by variant and attributes. */
+export type CheckoutLineItem = Node & {
+   __typename?: 'CheckoutLineItem',
+  /** Extra information in the form of an array of Key-Value pairs about the line item. */
+  customAttributes: Array<Attribute>,
+  /** The discounts that have been allocated onto the checkout line item by discount applications. */
+  discountAllocations: Array<DiscountAllocation>,
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** The quantity of the line item. */
+  quantity: Scalars['Int'],
+  /** Title of the line item. Defaults to the product's title. */
+  title: Scalars['String'],
+  /** Product variant of the line item. */
+  variant?: Maybe<ProductVariant>,
+};
+
+export type CheckoutLineItemConnection = {
+   __typename?: 'CheckoutLineItemConnection',
+  /** A list of edges. */
+  edges: Array<CheckoutLineItemEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type CheckoutLineItemEdge = {
+   __typename?: 'CheckoutLineItemEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of CheckoutLineItemEdge. */
+  node: CheckoutLineItem,
+};
+
+/** Specifies the input fields to create a line item on a checkout. */
+export type CheckoutLineItemInput = {
+  /** Extra information in the form of an array of Key-Value pairs about the line item. */
+  customAttributes?: Maybe<Array<AttributeInput>>,
+  /** The quantity of the line item. */
+  quantity: Scalars['Int'],
+  /** The identifier of the product variant for the line item. */
+  variantId: Scalars['ID'],
+};
+
+/** Return type for `checkoutLineItemsAdd` mutation. */
+export type CheckoutLineItemsAddPayload = {
+   __typename?: 'CheckoutLineItemsAddPayload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutLineItemsRemove` mutation. */
+export type CheckoutLineItemsRemovePayload = {
+   __typename?: 'CheckoutLineItemsRemovePayload',
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutLineItemsReplace` mutation. */
+export type CheckoutLineItemsReplacePayload = {
+   __typename?: 'CheckoutLineItemsReplacePayload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<CheckoutUserError>,
+};
+
+/** Return type for `checkoutLineItemsUpdate` mutation. */
+export type CheckoutLineItemsUpdatePayload = {
+   __typename?: 'CheckoutLineItemsUpdatePayload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Specifies the input fields to update a line item on the checkout. */
+export type CheckoutLineItemUpdateInput = {
+  id?: Maybe<Scalars['ID']>,
+  /** The variant identifier of the line item. */
+  variantId?: Maybe<Scalars['ID']>,
+  /** The quantity of the line item. */
+  quantity?: Maybe<Scalars['Int']>,
+  /** Extra information in the form of an array of Key-Value pairs about the line item. */
+  customAttributes?: Maybe<Array<AttributeInput>>,
+};
+
+/** Return type for `checkoutShippingAddressUpdate` mutation. */
+export type CheckoutShippingAddressUpdatePayload = {
+   __typename?: 'CheckoutShippingAddressUpdatePayload',
+  /** The updated checkout object. */
+  checkout: Checkout,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutShippingAddressUpdateV2` mutation. */
+export type CheckoutShippingAddressUpdateV2Payload = {
+   __typename?: 'CheckoutShippingAddressUpdateV2Payload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `checkoutShippingLineUpdate` mutation. */
+export type CheckoutShippingLineUpdatePayload = {
+   __typename?: 'CheckoutShippingLineUpdatePayload',
+  /** The updated checkout object. */
+  checkout?: Maybe<Checkout>,
+  /** List of errors that occurred executing the mutation. */
+  checkoutUserErrors: Array<CheckoutUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Represents an error that happens during execution of a checkout mutation. */
+export type CheckoutUserError = DisplayableError & {
+   __typename?: 'CheckoutUserError',
+  /** Error code to uniquely identify the error. */
+  code?: Maybe<CheckoutErrorCode>,
+  /** Path to the input field which caused the error. */
+  field?: Maybe<Array<Scalars['String']>>,
+  /** The error message. */
+  message: Scalars['String'],
+};
+
+/** 
+ * A collection represents a grouping of products that a shop owner can create to
+ * organize them or make their shops easier to browse.
+ **/
+export type Collection = Node & {
+   __typename?: 'Collection',
+  /** Stripped description of the collection, single line with HTML tags removed. */
+  description: Scalars['String'],
+  /** The description of the collection, complete with HTML formatting. */
+  descriptionHtml: Scalars['HTML'],
+  /** 
+ * A human-friendly unique string for the collection automatically generated from its title.
+   * Limit of 255 characters.
+ **/
+  handle: Scalars['String'],
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** Image associated with the collection. */
+  image?: Maybe<Image>,
+  /** List of products in the collection. */
+  products: ProductConnection,
+  /** The collection’s name. Limit of 255 characters. */
+  title: Scalars['String'],
+  /** The date and time when the collection was last modified. */
+  updatedAt: Scalars['DateTime'],
+};
+
+
+/** 
+ * A collection represents a grouping of products that a shop owner can create to
+ * organize them or make their shops easier to browse.
+ **/
+export type CollectionDescriptionArgs = {
+  truncateAt?: Maybe<Scalars['Int']>
+};
+
+
+/** 
+ * A collection represents a grouping of products that a shop owner can create to
+ * organize them or make their shops easier to browse.
+ **/
+export type CollectionImageArgs = {
+  maxWidth?: Maybe<Scalars['Int']>,
+  maxHeight?: Maybe<Scalars['Int']>,
+  crop?: Maybe<CropRegion>,
+  scale?: Maybe<Scalars['Int']>
+};
+
+
+/** 
+ * A collection represents a grouping of products that a shop owner can create to
+ * organize them or make their shops easier to browse.
+ **/
+export type CollectionProductsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<ProductCollectionSortKeys>
+};
+
+export type CollectionConnection = {
+   __typename?: 'CollectionConnection',
+  /** A list of edges. */
+  edges: Array<CollectionEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type CollectionEdge = {
+   __typename?: 'CollectionEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of CollectionEdge. */
+  node: Collection,
+};
+
+/** The set of valid sort keys for the collections query. */
+export enum CollectionSortKeys {
+  /** Sort by the `title` value. */
+  Title = 'TITLE',
+  /** Sort by the `updated_at` value. */
+  UpdatedAt = 'UPDATED_AT',
+  /** Sort by the `id` value. */
+  Id = 'ID',
+  /** 
+ * During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the
+   * results by relevance to the search term(s). When no search query is specified, this sort key is not
+   * deterministic and should not be used.
+ **/
+  Relevance = 'RELEVANCE'
+}
+
+export type Comment = Node & {
+   __typename?: 'Comment',
+  /** The comment’s author. */
+  author: CommentAuthor,
+  /** Stripped content of the comment, single line with HTML tags removed. */
+  content: Scalars['String'],
+  /** The content of the comment, complete with HTML formatting. */
+  contentHtml: Scalars['HTML'],
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+};
+
+
+export type CommentContentArgs = {
+  truncateAt?: Maybe<Scalars['Int']>
+};
+
+export type CommentAuthor = {
+   __typename?: 'CommentAuthor',
+  /** The author's email. */
+  email: Scalars['String'],
+  /** The author’s name. */
+  name: Scalars['String'],
+};
+
+export type CommentConnection = {
+   __typename?: 'CommentConnection',
+  /** A list of edges. */
+  edges: Array<CommentEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type CommentEdge = {
+   __typename?: 'CommentEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of CommentEdge. */
+  node: Comment,
+};
+
+/** ISO 3166-1 alpha-2 country codes with some differences. */
+export enum CountryCode {
+  /** Afghanistan. */
+  Af = 'AF',
+  /** Aland Islands. */
+  Ax = 'AX',
+  /** Albania. */
+  Al = 'AL',
+  /** Algeria. */
+  Dz = 'DZ',
+  /** Andorra. */
+  Ad = 'AD',
+  /** Angola. */
+  Ao = 'AO',
+  /** Anguilla. */
+  Ai = 'AI',
+  /** Antigua And Barbuda. */
+  Ag = 'AG',
+  /** Argentina. */
+  Ar = 'AR',
+  /** Armenia. */
+  Am = 'AM',
+  /** Aruba. */
+  Aw = 'AW',
+  /** Australia. */
+  Au = 'AU',
+  /** Austria. */
+  At = 'AT',
+  /** Azerbaijan. */
+  Az = 'AZ',
+  /** Bahamas. */
+  Bs = 'BS',
+  /** Bahrain. */
+  Bh = 'BH',
+  /** Bangladesh. */
+  Bd = 'BD',
+  /** Barbados. */
+  Bb = 'BB',
+  /** Belarus. */
+  By = 'BY',
+  /** Belgium. */
+  Be = 'BE',
+  /** Belize. */
+  Bz = 'BZ',
+  /** Benin. */
+  Bj = 'BJ',
+  /** Bermuda. */
+  Bm = 'BM',
+  /** Bhutan. */
+  Bt = 'BT',
+  /** Bolivia. */
+  Bo = 'BO',
+  /** Bosnia And Herzegovina. */
+  Ba = 'BA',
+  /** Botswana. */
+  Bw = 'BW',
+  /** Bouvet Island. */
+  Bv = 'BV',
+  /** Brazil. */
+  Br = 'BR',
+  /** British Indian Ocean Territory. */
+  Io = 'IO',
+  /** Brunei. */
+  Bn = 'BN',
+  /** Bulgaria. */
+  Bg = 'BG',
+  /** Burkina Faso. */
+  Bf = 'BF',
+  /** Burundi. */
+  Bi = 'BI',
+  /** Cambodia. */
+  Kh = 'KH',
+  /** Canada. */
+  Ca = 'CA',
+  /** Cape Verde. */
+  Cv = 'CV',
+  /** Caribbean Netherlands. */
+  Bq = 'BQ',
+  /** Cayman Islands. */
+  Ky = 'KY',
+  /** Central African Republic. */
+  Cf = 'CF',
+  /** Chad. */
+  Td = 'TD',
+  /** Chile. */
+  Cl = 'CL',
+  /** China. */
+  Cn = 'CN',
+  /** Christmas Island. */
+  Cx = 'CX',
+  /** Cocos (Keeling) Islands. */
+  Cc = 'CC',
+  /** Colombia. */
+  Co = 'CO',
+  /** Comoros. */
+  Km = 'KM',
+  /** Congo. */
+  Cg = 'CG',
+  /** Congo, The Democratic Republic Of The. */
+  Cd = 'CD',
+  /** Cook Islands. */
+  Ck = 'CK',
+  /** Costa Rica. */
+  Cr = 'CR',
+  /** Croatia. */
+  Hr = 'HR',
+  /** Cuba. */
+  Cu = 'CU',
+  /** Curaçao. */
+  Cw = 'CW',
+  /** Cyprus. */
+  Cy = 'CY',
+  /** Czech Republic. */
+  Cz = 'CZ',
+  /** Côte d'Ivoire. */
+  Ci = 'CI',
+  /** Denmark. */
+  Dk = 'DK',
+  /** Djibouti. */
+  Dj = 'DJ',
+  /** Dominica. */
+  Dm = 'DM',
+  /** Dominican Republic. */
+  Do = 'DO',
+  /** Ecuador. */
+  Ec = 'EC',
+  /** Egypt. */
+  Eg = 'EG',
+  /** El Salvador. */
+  Sv = 'SV',
+  /** Equatorial Guinea. */
+  Gq = 'GQ',
+  /** Eritrea. */
+  Er = 'ER',
+  /** Estonia. */
+  Ee = 'EE',
+  /** Eswatini. */
+  Sz = 'SZ',
+  /** Ethiopia. */
+  Et = 'ET',
+  /** Falkland Islands (Malvinas). */
+  Fk = 'FK',
+  /** Faroe Islands. */
+  Fo = 'FO',
+  /** Fiji. */
+  Fj = 'FJ',
+  /** Finland. */
+  Fi = 'FI',
+  /** France. */
+  Fr = 'FR',
+  /** French Guiana. */
+  Gf = 'GF',
+  /** French Polynesia. */
+  Pf = 'PF',
+  /** French Southern Territories. */
+  Tf = 'TF',
+  /** Gabon. */
+  Ga = 'GA',
+  /** Gambia. */
+  Gm = 'GM',
+  /** Georgia. */
+  Ge = 'GE',
+  /** Germany. */
+  De = 'DE',
+  /** Ghana. */
+  Gh = 'GH',
+  /** Gibraltar. */
+  Gi = 'GI',
+  /** Greece. */
+  Gr = 'GR',
+  /** Greenland. */
+  Gl = 'GL',
+  /** Grenada. */
+  Gd = 'GD',
+  /** Guadeloupe. */
+  Gp = 'GP',
+  /** Guatemala. */
+  Gt = 'GT',
+  /** Guernsey. */
+  Gg = 'GG',
+  /** Guinea. */
+  Gn = 'GN',
+  /** Guinea Bissau. */
+  Gw = 'GW',
+  /** Guyana. */
+  Gy = 'GY',
+  /** Haiti. */
+  Ht = 'HT',
+  /** Heard Island And Mcdonald Islands. */
+  Hm = 'HM',
+  /** Holy See (Vatican City State). */
+  Va = 'VA',
+  /** Honduras. */
+  Hn = 'HN',
+  /** Hong Kong. */
+  Hk = 'HK',
+  /** Hungary. */
+  Hu = 'HU',
+  /** Iceland. */
+  Is = 'IS',
+  /** India. */
+  In = 'IN',
+  /** Indonesia. */
+  Id = 'ID',
+  /** Iran, Islamic Republic Of. */
+  Ir = 'IR',
+  /** Iraq. */
+  Iq = 'IQ',
+  /** Ireland. */
+  Ie = 'IE',
+  /** Isle Of Man. */
+  Im = 'IM',
+  /** Israel. */
+  Il = 'IL',
+  /** Italy. */
+  It = 'IT',
+  /** Jamaica. */
+  Jm = 'JM',
+  /** Japan. */
+  Jp = 'JP',
+  /** Jersey. */
+  Je = 'JE',
+  /** Jordan. */
+  Jo = 'JO',
+  /** Kazakhstan. */
+  Kz = 'KZ',
+  /** Kenya. */
+  Ke = 'KE',
+  /** Kiribati. */
+  Ki = 'KI',
+  /** Korea, Democratic People's Republic Of. */
+  Kp = 'KP',
+  /** Kosovo. */
+  Xk = 'XK',
+  /** Kuwait. */
+  Kw = 'KW',
+  /** Kyrgyzstan. */
+  Kg = 'KG',
+  /** Lao People's Democratic Republic. */
+  La = 'LA',
+  /** Latvia. */
+  Lv = 'LV',
+  /** Lebanon. */
+  Lb = 'LB',
+  /** Lesotho. */
+  Ls = 'LS',
+  /** Liberia. */
+  Lr = 'LR',
+  /** Libyan Arab Jamahiriya. */
+  Ly = 'LY',
+  /** Liechtenstein. */
+  Li = 'LI',
+  /** Lithuania. */
+  Lt = 'LT',
+  /** Luxembourg. */
+  Lu = 'LU',
+  /** Macao. */
+  Mo = 'MO',
+  /** Madagascar. */
+  Mg = 'MG',
+  /** Malawi. */
+  Mw = 'MW',
+  /** Malaysia. */
+  My = 'MY',
+  /** Maldives. */
+  Mv = 'MV',
+  /** Mali. */
+  Ml = 'ML',
+  /** Malta. */
+  Mt = 'MT',
+  /** Martinique. */
+  Mq = 'MQ',
+  /** Mauritania. */
+  Mr = 'MR',
+  /** Mauritius. */
+  Mu = 'MU',
+  /** Mayotte. */
+  Yt = 'YT',
+  /** Mexico. */
+  Mx = 'MX',
+  /** Moldova, Republic of. */
+  Md = 'MD',
+  /** Monaco. */
+  Mc = 'MC',
+  /** Mongolia. */
+  Mn = 'MN',
+  /** Montenegro. */
+  Me = 'ME',
+  /** Montserrat. */
+  Ms = 'MS',
+  /** Morocco. */
+  Ma = 'MA',
+  /** Mozambique. */
+  Mz = 'MZ',
+  /** Myanmar. */
+  Mm = 'MM',
+  /** Namibia. */
+  Na = 'NA',
+  /** Nauru. */
+  Nr = 'NR',
+  /** Nepal. */
+  Np = 'NP',
+  /** Netherlands. */
+  Nl = 'NL',
+  /** Netherlands Antilles. */
+  An = 'AN',
+  /** New Caledonia. */
+  Nc = 'NC',
+  /** New Zealand. */
+  Nz = 'NZ',
+  /** Nicaragua. */
+  Ni = 'NI',
+  /** Niger. */
+  Ne = 'NE',
+  /** Nigeria. */
+  Ng = 'NG',
+  /** Niue. */
+  Nu = 'NU',
+  /** Norfolk Island. */
+  Nf = 'NF',
+  /** North Macedonia. */
+  Mk = 'MK',
+  /** Norway. */
+  No = 'NO',
+  /** Oman. */
+  Om = 'OM',
+  /** Pakistan. */
+  Pk = 'PK',
+  /** Palestinian Territory, Occupied. */
+  Ps = 'PS',
+  /** Panama. */
+  Pa = 'PA',
+  /** Papua New Guinea. */
+  Pg = 'PG',
+  /** Paraguay. */
+  Py = 'PY',
+  /** Peru. */
+  Pe = 'PE',
+  /** Philippines. */
+  Ph = 'PH',
+  /** Pitcairn. */
+  Pn = 'PN',
+  /** Poland. */
+  Pl = 'PL',
+  /** Portugal. */
+  Pt = 'PT',
+  /** Qatar. */
+  Qa = 'QA',
+  /** Republic of Cameroon. */
+  Cm = 'CM',
+  /** Reunion. */
+  Re = 'RE',
+  /** Romania. */
+  Ro = 'RO',
+  /** Russia. */
+  Ru = 'RU',
+  /** Rwanda. */
+  Rw = 'RW',
+  /** Saint Barthélemy. */
+  Bl = 'BL',
+  /** Saint Helena. */
+  Sh = 'SH',
+  /** Saint Kitts And Nevis. */
+  Kn = 'KN',
+  /** Saint Lucia. */
+  Lc = 'LC',
+  /** Saint Martin. */
+  Mf = 'MF',
+  /** Saint Pierre And Miquelon. */
+  Pm = 'PM',
+  /** Samoa. */
+  Ws = 'WS',
+  /** San Marino. */
+  Sm = 'SM',
+  /** Sao Tome And Principe. */
+  St = 'ST',
+  /** Saudi Arabia. */
+  Sa = 'SA',
+  /** Senegal. */
+  Sn = 'SN',
+  /** Serbia. */
+  Rs = 'RS',
+  /** Seychelles. */
+  Sc = 'SC',
+  /** Sierra Leone. */
+  Sl = 'SL',
+  /** Singapore. */
+  Sg = 'SG',
+  /** Sint Maarten. */
+  Sx = 'SX',
+  /** Slovakia. */
+  Sk = 'SK',
+  /** Slovenia. */
+  Si = 'SI',
+  /** Solomon Islands. */
+  Sb = 'SB',
+  /** Somalia. */
+  So = 'SO',
+  /** South Africa. */
+  Za = 'ZA',
+  /** South Georgia And The South Sandwich Islands. */
+  Gs = 'GS',
+  /** South Korea. */
+  Kr = 'KR',
+  /** South Sudan. */
+  Ss = 'SS',
+  /** Spain. */
+  Es = 'ES',
+  /** Sri Lanka. */
+  Lk = 'LK',
+  /** St. Vincent. */
+  Vc = 'VC',
+  /** Sudan. */
+  Sd = 'SD',
+  /** Suriname. */
+  Sr = 'SR',
+  /** Svalbard And Jan Mayen. */
+  Sj = 'SJ',
+  /** Sweden. */
+  Se = 'SE',
+  /** Switzerland. */
+  Ch = 'CH',
+  /** Syria. */
+  Sy = 'SY',
+  /** Taiwan. */
+  Tw = 'TW',
+  /** Tajikistan. */
+  Tj = 'TJ',
+  /** Tanzania, United Republic Of. */
+  Tz = 'TZ',
+  /** Thailand. */
+  Th = 'TH',
+  /** Timor Leste. */
+  Tl = 'TL',
+  /** Togo. */
+  Tg = 'TG',
+  /** Tokelau. */
+  Tk = 'TK',
+  /** Tonga. */
+  To = 'TO',
+  /** Trinidad and Tobago. */
+  Tt = 'TT',
+  /** Tunisia. */
+  Tn = 'TN',
+  /** Turkey. */
+  Tr = 'TR',
+  /** Turkmenistan. */
+  Tm = 'TM',
+  /** Turks and Caicos Islands. */
+  Tc = 'TC',
+  /** Tuvalu. */
+  Tv = 'TV',
+  /** Uganda. */
+  Ug = 'UG',
+  /** Ukraine. */
+  Ua = 'UA',
+  /** United Arab Emirates. */
+  Ae = 'AE',
+  /** United Kingdom. */
+  Gb = 'GB',
+  /** United States. */
+  Us = 'US',
+  /** United States Minor Outlying Islands. */
+  Um = 'UM',
+  /** Uruguay. */
+  Uy = 'UY',
+  /** Uzbekistan. */
+  Uz = 'UZ',
+  /** Vanuatu. */
+  Vu = 'VU',
+  /** Venezuela. */
+  Ve = 'VE',
+  /** Vietnam. */
+  Vn = 'VN',
+  /** Virgin Islands, British. */
+  Vg = 'VG',
+  /** Wallis And Futuna. */
+  Wf = 'WF',
+  /** Western Sahara. */
+  Eh = 'EH',
+  /** Yemen. */
+  Ye = 'YE',
+  /** Zambia. */
+  Zm = 'ZM',
+  /** Zimbabwe. */
+  Zw = 'ZW'
+}
+
+/** Credit card information used for a payment. */
+export type CreditCard = {
+   __typename?: 'CreditCard',
+  brand?: Maybe<Scalars['String']>,
+  expiryMonth?: Maybe<Scalars['Int']>,
+  expiryYear?: Maybe<Scalars['Int']>,
+  firstDigits?: Maybe<Scalars['String']>,
+  firstName?: Maybe<Scalars['String']>,
+  lastDigits?: Maybe<Scalars['String']>,
+  lastName?: Maybe<Scalars['String']>,
+  /** Masked credit card number with only the last 4 digits displayed */
+  maskedNumber?: Maybe<Scalars['String']>,
+};
+
+/** 
+ * Specifies the fields required to complete a checkout with
+ * a Shopify vaulted credit card payment.
+ **/
+export type CreditCardPaymentInput = {
+  /** The amount of the payment. */
+  amount: Scalars['Money'],
+  /** 
+ * A unique client generated key used to avoid duplicate charges. When a
+   * duplicate payment is found, the original is returned instead of creating a new one.
+ **/
+  idempotencyKey: Scalars['String'],
+  /** The billing address for the payment. */
+  billingAddress: MailingAddressInput,
+  /** The ID returned by Shopify's Card Vault. */
+  vaultId: Scalars['String'],
+  /** Executes the payment in test mode if possible. Defaults to `false`. */
+  test?: Maybe<Scalars['Boolean']>,
+};
+
+/** 
+ * Specifies the fields required to complete a checkout with
+ * a Shopify vaulted credit card payment.
+ **/
+export type CreditCardPaymentInputV2 = {
+  /** The amount and currency of the payment. */
+  paymentAmount: MoneyInput,
+  /** 
+ * A unique client generated key used to avoid duplicate charges. When a
+   * duplicate payment is found, the original is returned instead of creating a new one.
+ **/
+  idempotencyKey: Scalars['String'],
+  /** The billing address for the payment. */
+  billingAddress: MailingAddressInput,
+  /** The ID returned by Shopify's Card Vault. */
+  vaultId: Scalars['String'],
+  /** Executes the payment in test mode if possible. Defaults to `false`. */
+  test?: Maybe<Scalars['Boolean']>,
+};
+
+/** The part of the image that should remain after cropping. */
+export enum CropRegion {
+  /** Keep the center of the image */
+  Center = 'CENTER',
+  /** Keep the top of the image */
+  Top = 'TOP',
+  /** Keep the bottom of the image */
+  Bottom = 'BOTTOM',
+  /** Keep the left of the image */
+  Left = 'LEFT',
+  /** Keep the right of the image */
+  Right = 'RIGHT'
+}
+
+/** Currency codes */
+export enum CurrencyCode {
+  /** United States Dollars (USD). */
+  Usd = 'USD',
+  /** Euro (EUR). */
+  Eur = 'EUR',
+  /** United Kingdom Pounds (GBP). */
+  Gbp = 'GBP',
+  /** Canadian Dollars (CAD). */
+  Cad = 'CAD',
+  /** Afghan Afghani (AFN). */
+  Afn = 'AFN',
+  /** Albanian Lek (ALL). */
+  All = 'ALL',
+  /** Algerian Dinar (DZD). */
+  Dzd = 'DZD',
+  /** Angolan Kwanza (AOA). */
+  Aoa = 'AOA',
+  /** Argentine Pesos (ARS). */
+  Ars = 'ARS',
+  /** Armenian Dram (AMD). */
+  Amd = 'AMD',
+  /** Aruban Florin (AWG). */
+  Awg = 'AWG',
+  /** Australian Dollars (AUD). */
+  Aud = 'AUD',
+  /** Barbadian Dollar (BBD). */
+  Bbd = 'BBD',
+  /** Azerbaijani Manat (AZN). */
+  Azn = 'AZN',
+  /** Bangladesh Taka (BDT). */
+  Bdt = 'BDT',
+  /** Bahamian Dollar (BSD). */
+  Bsd = 'BSD',
+  /** Bahraini Dinar (BHD). */
+  Bhd = 'BHD',
+  /** Burundian Franc (BIF). */
+  Bif = 'BIF',
+  /** Belarusian Ruble (BYR). */
+  Byr = 'BYR',
+  /** Belize Dollar (BZD). */
+  Bzd = 'BZD',
+  /** Bermudian Dollar (BMD). */
+  Bmd = 'BMD',
+  /** Bhutanese Ngultrum (BTN). */
+  Btn = 'BTN',
+  /** Bosnia and Herzegovina Convertible Mark (BAM). */
+  Bam = 'BAM',
+  /** Brazilian Real (BRL). */
+  Brl = 'BRL',
+  /** Bolivian Boliviano (BOB). */
+  Bob = 'BOB',
+  /** Botswana Pula (BWP). */
+  Bwp = 'BWP',
+  /** Brunei Dollar (BND). */
+  Bnd = 'BND',
+  /** Bulgarian Lev (BGN). */
+  Bgn = 'BGN',
+  /** Burmese Kyat (MMK). */
+  Mmk = 'MMK',
+  /** Cambodian Riel. */
+  Khr = 'KHR',
+  /** Cape Verdean escudo (CVE). */
+  Cve = 'CVE',
+  /** Cayman Dollars (KYD). */
+  Kyd = 'KYD',
+  /** Central African CFA Franc (XAF). */
+  Xaf = 'XAF',
+  /** Chilean Peso (CLP). */
+  Clp = 'CLP',
+  /** Chinese Yuan Renminbi (CNY). */
+  Cny = 'CNY',
+  /** Colombian Peso (COP). */
+  Cop = 'COP',
+  /** Comorian Franc (KMF). */
+  Kmf = 'KMF',
+  /** Congolese franc (CDF). */
+  Cdf = 'CDF',
+  /** Costa Rican Colones (CRC). */
+  Crc = 'CRC',
+  /** Croatian Kuna (HRK). */
+  Hrk = 'HRK',
+  /** Czech Koruny (CZK). */
+  Czk = 'CZK',
+  /** Danish Kroner (DKK). */
+  Dkk = 'DKK',
+  /** Djiboutian Franc (DJF). */
+  Djf = 'DJF',
+  /** Dominican Peso (DOP). */
+  Dop = 'DOP',
+  /** East Caribbean Dollar (XCD). */
+  Xcd = 'XCD',
+  /** Egyptian Pound (EGP). */
+  Egp = 'EGP',
+  /** Ethiopian Birr (ETB). */
+  Etb = 'ETB',
+  /** CFP Franc (XPF). */
+  Xpf = 'XPF',
+  /** Fijian Dollars (FJD). */
+  Fjd = 'FJD',
+  /** Gambian Dalasi (GMD). */
+  Gmd = 'GMD',
+  /** Ghanaian Cedi (GHS). */
+  Ghs = 'GHS',
+  /** Guatemalan Quetzal (GTQ). */
+  Gtq = 'GTQ',
+  /** Guyanese Dollar (GYD). */
+  Gyd = 'GYD',
+  /** Georgian Lari (GEL). */
+  Gel = 'GEL',
+  /** Guinean Franc (GNF). */
+  Gnf = 'GNF',
+  /** Haitian Gourde (HTG). */
+  Htg = 'HTG',
+  /** Honduran Lempira (HNL). */
+  Hnl = 'HNL',
+  /** Hong Kong Dollars (HKD). */
+  Hkd = 'HKD',
+  /** Hungarian Forint (HUF). */
+  Huf = 'HUF',
+  /** Icelandic Kronur (ISK). */
+  Isk = 'ISK',
+  /** Indian Rupees (INR). */
+  Inr = 'INR',
+  /** Indonesian Rupiah (IDR). */
+  Idr = 'IDR',
+  /** Israeli New Shekel (NIS). */
+  Ils = 'ILS',
+  /** Iranian Rial (IRR). */
+  Irr = 'IRR',
+  /** Iraqi Dinar (IQD). */
+  Iqd = 'IQD',
+  /** Jamaican Dollars (JMD). */
+  Jmd = 'JMD',
+  /** Japanese Yen (JPY). */
+  Jpy = 'JPY',
+  /** Jersey Pound. */
+  Jep = 'JEP',
+  /** Jordanian Dinar (JOD). */
+  Jod = 'JOD',
+  /** Kazakhstani Tenge (KZT). */
+  Kzt = 'KZT',
+  /** Kenyan Shilling (KES). */
+  Kes = 'KES',
+  /** Kuwaiti Dinar (KWD). */
+  Kwd = 'KWD',
+  /** Kyrgyzstani Som (KGS). */
+  Kgs = 'KGS',
+  /** Laotian Kip (LAK). */
+  Lak = 'LAK',
+  /** Latvian Lati (LVL). */
+  Lvl = 'LVL',
+  /** Lebanese Pounds (LBP). */
+  Lbp = 'LBP',
+  /** Lesotho Loti (LSL). */
+  Lsl = 'LSL',
+  /** Liberian Dollar (LRD). */
+  Lrd = 'LRD',
+  /** Libyan Dinar (LYD). */
+  Lyd = 'LYD',
+  /** Lithuanian Litai (LTL). */
+  Ltl = 'LTL',
+  /** Malagasy Ariary (MGA). */
+  Mga = 'MGA',
+  /** Macedonia Denar (MKD). */
+  Mkd = 'MKD',
+  /** Macanese Pataca (MOP). */
+  Mop = 'MOP',
+  /** Malawian Kwacha (MWK). */
+  Mwk = 'MWK',
+  /** Maldivian Rufiyaa (MVR). */
+  Mvr = 'MVR',
+  /** Mexican Pesos (MXN). */
+  Mxn = 'MXN',
+  /** Malaysian Ringgits (MYR). */
+  Myr = 'MYR',
+  /** Mauritian Rupee (MUR). */
+  Mur = 'MUR',
+  /** Moldovan Leu (MDL). */
+  Mdl = 'MDL',
+  /** Moroccan Dirham. */
+  Mad = 'MAD',
+  /** Mongolian Tugrik. */
+  Mnt = 'MNT',
+  /** Mozambican Metical. */
+  Mzn = 'MZN',
+  /** Namibian Dollar. */
+  Nad = 'NAD',
+  /** Nepalese Rupee (NPR). */
+  Npr = 'NPR',
+  /** Netherlands Antillean Guilder. */
+  Ang = 'ANG',
+  /** New Zealand Dollars (NZD). */
+  Nzd = 'NZD',
+  /** Nicaraguan Córdoba (NIO). */
+  Nio = 'NIO',
+  /** Nigerian Naira (NGN). */
+  Ngn = 'NGN',
+  /** Norwegian Kroner (NOK). */
+  Nok = 'NOK',
+  /** Omani Rial (OMR). */
+  Omr = 'OMR',
+  /** Panamian Balboa (PAB). */
+  Pab = 'PAB',
+  /** Pakistani Rupee (PKR). */
+  Pkr = 'PKR',
+  /** Papua New Guinean Kina (PGK). */
+  Pgk = 'PGK',
+  /** Paraguayan Guarani (PYG). */
+  Pyg = 'PYG',
+  /** Peruvian Nuevo Sol (PEN). */
+  Pen = 'PEN',
+  /** Philippine Peso (PHP). */
+  Php = 'PHP',
+  /** Polish Zlotych (PLN). */
+  Pln = 'PLN',
+  /** Qatari Rial (QAR). */
+  Qar = 'QAR',
+  /** Romanian Lei (RON). */
+  Ron = 'RON',
+  /** Russian Rubles (RUB). */
+  Rub = 'RUB',
+  /** Rwandan Franc (RWF). */
+  Rwf = 'RWF',
+  /** Samoan Tala (WST). */
+  Wst = 'WST',
+  /** Saudi Riyal (SAR). */
+  Sar = 'SAR',
+  /** Sao Tome And Principe Dobra (STD). */
+  Std = 'STD',
+  /** Serbian dinar (RSD). */
+  Rsd = 'RSD',
+  /** Seychellois Rupee (SCR). */
+  Scr = 'SCR',
+  /** Sierra Leonean Leone (SLL). */
+  Sll = 'SLL',
+  /** Singapore Dollars (SGD). */
+  Sgd = 'SGD',
+  /** Sudanese Pound (SDG). */
+  Sdg = 'SDG',
+  /** Syrian Pound (SYP). */
+  Syp = 'SYP',
+  /** South African Rand (ZAR). */
+  Zar = 'ZAR',
+  /** South Korean Won (KRW). */
+  Krw = 'KRW',
+  /** South Sudanese Pound (SSP). */
+  Ssp = 'SSP',
+  /** Solomon Islands Dollar (SBD). */
+  Sbd = 'SBD',
+  /** Sri Lankan Rupees (LKR). */
+  Lkr = 'LKR',
+  /** Surinamese Dollar (SRD). */
+  Srd = 'SRD',
+  /** Swazi Lilangeni (SZL). */
+  Szl = 'SZL',
+  /** Swedish Kronor (SEK). */
+  Sek = 'SEK',
+  /** Swiss Francs (CHF). */
+  Chf = 'CHF',
+  /** Taiwan Dollars (TWD). */
+  Twd = 'TWD',
+  /** Thai baht (THB). */
+  Thb = 'THB',
+  /** Tajikistani Somoni (TJS). */
+  Tjs = 'TJS',
+  /** Tanzanian Shilling (TZS). */
+  Tzs = 'TZS',
+  /** Tongan Pa'anga (TOP). */
+  Top = 'TOP',
+  /** Trinidad and Tobago Dollars (TTD). */
+  Ttd = 'TTD',
+  /** Tunisian Dinar (TND). */
+  Tnd = 'TND',
+  /** Turkish Lira (TRY). */
+  Try = 'TRY',
+  /** Turkmenistani Manat (TMT). */
+  Tmt = 'TMT',
+  /** Ugandan Shilling (UGX). */
+  Ugx = 'UGX',
+  /** Ukrainian Hryvnia (UAH). */
+  Uah = 'UAH',
+  /** United Arab Emirates Dirham (AED). */
+  Aed = 'AED',
+  /** Uruguayan Pesos (UYU). */
+  Uyu = 'UYU',
+  /** Uzbekistan som (UZS). */
+  Uzs = 'UZS',
+  /** Vanuatu Vatu (VUV). */
+  Vuv = 'VUV',
+  /** Venezuelan Bolivares (VEF). */
+  Vef = 'VEF',
+  /** Vietnamese đồng (VND). */
+  Vnd = 'VND',
+  /** West African CFA franc (XOF). */
+  Xof = 'XOF',
+  /** Yemeni Rial (YER). */
+  Yer = 'YER',
+  /** Zambian Kwacha (ZMW). */
+  Zmw = 'ZMW'
+}
+
+/** 
+ * A customer represents a customer account with the shop. Customer accounts store
+ * contact information for the customer, saving logged-in customers the trouble of
+ * having to provide it at every checkout.
+ **/
+export type Customer = {
+   __typename?: 'Customer',
+  /** Indicates whether the customer has consented to be sent marketing material via email. */
+  acceptsMarketing: Scalars['Boolean'],
+  /** A list of addresses for the customer. */
+  addresses: MailingAddressConnection,
+  /** The date and time when the customer was created. */
+  createdAt: Scalars['DateTime'],
+  /** The customer’s default address. */
+  defaultAddress?: Maybe<MailingAddress>,
+  /** The customer’s name, email or phone number. */
+  displayName: Scalars['String'],
+  /** The customer’s email address. */
+  email?: Maybe<Scalars['String']>,
+  /** The customer’s first name. */
+  firstName?: Maybe<Scalars['String']>,
+  /** A unique identifier for the customer. */
+  id: Scalars['ID'],
+  /** The customer's most recently updated, incomplete checkout. */
+  lastIncompleteCheckout?: Maybe<Checkout>,
+  /** The customer’s last name. */
+  lastName?: Maybe<Scalars['String']>,
+  /** The orders associated with the customer. */
+  orders: OrderConnection,
+  /** The customer’s phone number. */
+  phone?: Maybe<Scalars['String']>,
+  /** 
+ * A list of tags assigned to the customer.
+   * Additional access scope required: unauthenticated_read_customer_tags.
+ **/
+  tags: Array<Scalars['String']>,
+  /** The date and time when the customer information was updated. */
+  updatedAt: Scalars['DateTime'],
+};
+
+
+/** 
+ * A customer represents a customer account with the shop. Customer accounts store
+ * contact information for the customer, saving logged-in customers the trouble of
+ * having to provide it at every checkout.
+ **/
+export type CustomerAddressesArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** 
+ * A customer represents a customer account with the shop. Customer accounts store
+ * contact information for the customer, saving logged-in customers the trouble of
+ * having to provide it at every checkout.
+ **/
+export type CustomerOrdersArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<OrderSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+/** A CustomerAccessToken represents the unique token required to make modifications to the customer object. */
+export type CustomerAccessToken = {
+   __typename?: 'CustomerAccessToken',
+  /** The customer’s access token. */
+  accessToken: Scalars['String'],
+  /** The date and time when the customer access token expires. */
+  expiresAt: Scalars['DateTime'],
+};
+
+/** Specifies the input fields required to create a customer access token. */
+export type CustomerAccessTokenCreateInput = {
+  /** The email associated to the customer. */
+  email: Scalars['String'],
+  /** The login password to be used by the customer. */
+  password: Scalars['String'],
+};
+
+/** Return type for `customerAccessTokenCreate` mutation. */
+export type CustomerAccessTokenCreatePayload = {
+   __typename?: 'CustomerAccessTokenCreatePayload',
+  /** The newly created customer access token object. */
+  customerAccessToken?: Maybe<CustomerAccessToken>,
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `customerAccessTokenDelete` mutation. */
+export type CustomerAccessTokenDeletePayload = {
+   __typename?: 'CustomerAccessTokenDeletePayload',
+  /** The destroyed access token. */
+  deletedAccessToken?: Maybe<Scalars['String']>,
+  /** ID of the destroyed customer access token. */
+  deletedCustomerAccessTokenId?: Maybe<Scalars['String']>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `customerAccessTokenRenew` mutation. */
+export type CustomerAccessTokenRenewPayload = {
+   __typename?: 'CustomerAccessTokenRenewPayload',
+  /** The renewed customer access token object. */
+  customerAccessToken?: Maybe<CustomerAccessToken>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Specifies the input fields required to activate a customer. */
+export type CustomerActivateInput = {
+  /** The activation token required to activate the customer. */
+  activationToken: Scalars['String'],
+  /** New password that will be set during activation. */
+  password: Scalars['String'],
+};
+
+/** Return type for `customerActivate` mutation. */
+export type CustomerActivatePayload = {
+   __typename?: 'CustomerActivatePayload',
+  /** The customer object. */
+  customer?: Maybe<Customer>,
+  /** A newly created customer access token object for the customer. */
+  customerAccessToken?: Maybe<CustomerAccessToken>,
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `customerAddressCreate` mutation. */
+export type CustomerAddressCreatePayload = {
+   __typename?: 'CustomerAddressCreatePayload',
+  /** The new customer address object. */
+  customerAddress?: Maybe<MailingAddress>,
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `customerAddressDelete` mutation. */
+export type CustomerAddressDeletePayload = {
+   __typename?: 'CustomerAddressDeletePayload',
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** ID of the deleted customer address. */
+  deletedCustomerAddressId?: Maybe<Scalars['String']>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `customerAddressUpdate` mutation. */
+export type CustomerAddressUpdatePayload = {
+   __typename?: 'CustomerAddressUpdatePayload',
+  /** The customer’s updated mailing address. */
+  customerAddress?: Maybe<MailingAddress>,
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Specifies the fields required to create a new Customer. */
+export type CustomerCreateInput = {
+  /** The customer’s first name. */
+  firstName?: Maybe<Scalars['String']>,
+  /** The customer’s last name. */
+  lastName?: Maybe<Scalars['String']>,
+  /** The customer’s email. */
+  email: Scalars['String'],
+  /** The customer’s phone number. */
+  phone?: Maybe<Scalars['String']>,
+  /** The login password used by the customer. */
+  password: Scalars['String'],
+  /** Indicates whether the customer has consented to be sent marketing material via email. */
+  acceptsMarketing?: Maybe<Scalars['Boolean']>,
+};
+
+/** Return type for `customerCreate` mutation. */
+export type CustomerCreatePayload = {
+   __typename?: 'CustomerCreatePayload',
+  /** The created customer object. */
+  customer?: Maybe<Customer>,
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `customerDefaultAddressUpdate` mutation. */
+export type CustomerDefaultAddressUpdatePayload = {
+   __typename?: 'CustomerDefaultAddressUpdatePayload',
+  /** The updated customer object. */
+  customer?: Maybe<Customer>,
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Possible error codes that could be returned by a customer mutation. */
+export enum CustomerErrorCode {
+  /** Input value is blank. */
+  Blank = 'BLANK',
+  /** Input value is invalid. */
+  Invalid = 'INVALID',
+  /** Input value is already taken. */
+  Taken = 'TAKEN',
+  /** Input value is too long. */
+  TooLong = 'TOO_LONG',
+  /** Input value is too short. */
+  TooShort = 'TOO_SHORT',
+  /** Unidentified customer. */
+  UnidentifiedCustomer = 'UNIDENTIFIED_CUSTOMER',
+  /** Customer is disabled. */
+  CustomerDisabled = 'CUSTOMER_DISABLED',
+  /** Input password starts or ends with whitespace. */
+  PasswordStartsOrEndsWithWhitespace = 'PASSWORD_STARTS_OR_ENDS_WITH_WHITESPACE',
+  /** Input contains HTML tags. */
+  ContainsHtmlTags = 'CONTAINS_HTML_TAGS',
+  /** Input contains URL. */
+  ContainsUrl = 'CONTAINS_URL',
+  /** Invalid activation token. */
+  TokenInvalid = 'TOKEN_INVALID',
+  /** Customer already enabled. */
+  AlreadyEnabled = 'ALREADY_ENABLED',
+  /** Address does not exist. */
+  NotFound = 'NOT_FOUND'
+}
+
+/** Return type for `customerRecover` mutation. */
+export type CustomerRecoverPayload = {
+   __typename?: 'CustomerRecoverPayload',
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Return type for `customerResetByUrl` mutation. */
+export type CustomerResetByUrlPayload = {
+   __typename?: 'CustomerResetByUrlPayload',
+  /** The customer object which was reset. */
+  customer?: Maybe<Customer>,
+  /** A newly created customer access token object for the customer. */
+  customerAccessToken?: Maybe<CustomerAccessToken>,
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Specifies the fields required to reset a Customer’s password. */
+export type CustomerResetInput = {
+  /** The reset token required to reset the customer’s password. */
+  resetToken: Scalars['String'],
+  /** New password that will be set as part of the reset password process. */
+  password: Scalars['String'],
+};
+
+/** Return type for `customerReset` mutation. */
+export type CustomerResetPayload = {
+   __typename?: 'CustomerResetPayload',
+  /** The customer object which was reset. */
+  customer?: Maybe<Customer>,
+  /** A newly created customer access token object for the customer. */
+  customerAccessToken?: Maybe<CustomerAccessToken>,
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Specifies the fields required to update the Customer information. */
+export type CustomerUpdateInput = {
+  /** The customer’s first name. */
+  firstName?: Maybe<Scalars['String']>,
+  /** The customer’s last name. */
+  lastName?: Maybe<Scalars['String']>,
+  /** The customer’s email. */
+  email?: Maybe<Scalars['String']>,
+  /** The customer’s phone number. */
+  phone?: Maybe<Scalars['String']>,
+  /** The login password used by the customer. */
+  password?: Maybe<Scalars['String']>,
+  /** Indicates whether the customer has consented to be sent marketing material via email. */
+  acceptsMarketing?: Maybe<Scalars['Boolean']>,
+};
+
+/** Return type for `customerUpdate` mutation. */
+export type CustomerUpdatePayload = {
+   __typename?: 'CustomerUpdatePayload',
+  /** The updated customer object. */
+  customer?: Maybe<Customer>,
+  /** 
+ * The newly created customer access token. If the customer's password is updated, all previous access tokens
+   * (including the one used to perform this mutation) become invalid, and a new token is generated.
+ **/
+  customerAccessToken?: Maybe<CustomerAccessToken>,
+  /** List of errors that occurred executing the mutation. */
+  customerUserErrors: Array<CustomerUserError>,
+  /** List of errors that occurred executing the mutation. */
+  userErrors: Array<UserError>,
+};
+
+/** Represents an error that happens during execution of a customer mutation. */
+export type CustomerUserError = DisplayableError & {
+   __typename?: 'CustomerUserError',
+  /** Error code to uniquely identify the error. */
+  code?: Maybe<CustomerErrorCode>,
+  /** Path to the input field which caused the error. */
+  field?: Maybe<Array<Scalars['String']>>,
+  /** The error message. */
+  message: Scalars['String'],
+};
+
+
+
+/** Digital wallet, such as Apple Pay, which can be used for accelerated checkouts. */
+export enum DigitalWallet {
+  /** Apple Pay. */
+  ApplePay = 'APPLE_PAY',
+  /** Android Pay. */
+  AndroidPay = 'ANDROID_PAY',
+  /** Google Pay. */
+  GooglePay = 'GOOGLE_PAY',
+  /** Shopify Pay. */
+  ShopifyPay = 'SHOPIFY_PAY'
+}
+
+/** An amount discounting the line that has been allocated by a discount. */
+export type DiscountAllocation = {
+   __typename?: 'DiscountAllocation',
+  /** Amount of discount allocated. */
+  allocatedAmount: MoneyV2,
+  /** The discount this allocated amount originated from. */
+  discountApplication: DiscountApplication,
+};
+
+/** 
+ * Discount applications capture the intentions of a discount source at
+ * the time of application.
+ **/
+export type DiscountApplication = {
+  /** The method by which the discount's value is allocated to its entitled items. */
+  allocationMethod: DiscountApplicationAllocationMethod,
+  /** Which lines of targetType that the discount is allocated over. */
+  targetSelection: DiscountApplicationTargetSelection,
+  /** The type of line that the discount is applicable towards. */
+  targetType: DiscountApplicationTargetType,
+  /** The value of the discount application. */
+  value: PricingValue,
+};
+
+/** The method by which the discount's value is allocated onto its entitled lines. */
+export enum DiscountApplicationAllocationMethod {
+  /** The value is spread across all entitled lines. */
+  Across = 'ACROSS',
+  /** The value is applied onto every entitled line. */
+  Each = 'EACH',
+  /** The value is specifically applied onto a particular line. */
+  One = 'ONE'
+}
+
+export type DiscountApplicationConnection = {
+   __typename?: 'DiscountApplicationConnection',
+  /** A list of edges. */
+  edges: Array<DiscountApplicationEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type DiscountApplicationEdge = {
+   __typename?: 'DiscountApplicationEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of DiscountApplicationEdge. */
+  node: DiscountApplication,
+};
+
+/** 
+ * Which lines on the order that the discount is allocated over, of the type
+ * defined by the Discount Application's target_type.
+ **/
+export enum DiscountApplicationTargetSelection {
+  /** The discount is allocated onto all the lines. */
+  All = 'ALL',
+  /** The discount is allocated onto only the lines it is entitled for. */
+  Entitled = 'ENTITLED',
+  /** The discount is allocated onto explicitly chosen lines. */
+  Explicit = 'EXPLICIT'
+}
+
+/** The type of line (i.e. line item or shipping line) on an order that the discount is applicable towards. */
+export enum DiscountApplicationTargetType {
+  /** The discount applies onto line items. */
+  LineItem = 'LINE_ITEM',
+  /** The discount applies onto shipping lines. */
+  ShippingLine = 'SHIPPING_LINE'
+}
+
+/** 
+ * Discount code applications capture the intentions of a discount code at
+ * the time that it is applied.
+ **/
+export type DiscountCodeApplication = DiscountApplication & {
+   __typename?: 'DiscountCodeApplication',
+  /** The method by which the discount's value is allocated to its entitled items. */
+  allocationMethod: DiscountApplicationAllocationMethod,
+  /** Specifies whether the discount code was applied successfully. */
+  applicable: Scalars['Boolean'],
+  /** The string identifying the discount code that was used at the time of application. */
+  code: Scalars['String'],
+  /** Which lines of targetType that the discount is allocated over. */
+  targetSelection: DiscountApplicationTargetSelection,
+  /** The type of line that the discount is applicable towards. */
+  targetType: DiscountApplicationTargetType,
+  /** The value of the discount application. */
+  value: PricingValue,
+};
+
+/** Represents an error in the input of a mutation. */
+export type DisplayableError = {
+  /** Path to the input field which caused the error. */
+  field?: Maybe<Array<Scalars['String']>>,
+  /** The error message. */
+  message: Scalars['String'],
+};
+
+/** Represents a web address. */
+export type Domain = {
+   __typename?: 'Domain',
+  /** The host name of the domain (eg: `example.com`). */
+  host: Scalars['String'],
+  /** Whether SSL is enabled or not. */
+  sslEnabled: Scalars['Boolean'],
+  /** The URL of the domain (eg: `https://example.com`). */
+  url: Scalars['URL'],
+};
+
+/** Represents a single fulfillment in an order. */
+export type Fulfillment = {
+   __typename?: 'Fulfillment',
+  /** List of the fulfillment's line items. */
+  fulfillmentLineItems: FulfillmentLineItemConnection,
+  /** The name of the tracking company. */
+  trackingCompany?: Maybe<Scalars['String']>,
+  /** 
+ * Tracking information associated with the fulfillment,
+   * such as the tracking number and tracking URL.
+ **/
+  trackingInfo: Array<FulfillmentTrackingInfo>,
+};
+
+
+/** Represents a single fulfillment in an order. */
+export type FulfillmentFulfillmentLineItemsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** Represents a single fulfillment in an order. */
+export type FulfillmentTrackingInfoArgs = {
+  first?: Maybe<Scalars['Int']>
+};
+
+/** Represents a single line item in a fulfillment. There is at most one fulfillment line item for each order line item. */
+export type FulfillmentLineItem = {
+   __typename?: 'FulfillmentLineItem',
+  /** The associated order's line item. */
+  lineItem: OrderLineItem,
+  /** The amount fulfilled in this fulfillment. */
+  quantity: Scalars['Int'],
+};
+
+export type FulfillmentLineItemConnection = {
+   __typename?: 'FulfillmentLineItemConnection',
+  /** A list of edges. */
+  edges: Array<FulfillmentLineItemEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type FulfillmentLineItemEdge = {
+   __typename?: 'FulfillmentLineItemEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of FulfillmentLineItemEdge. */
+  node: FulfillmentLineItem,
+};
+
+/** Tracking information associated with the fulfillment. */
+export type FulfillmentTrackingInfo = {
+   __typename?: 'FulfillmentTrackingInfo',
+  /** The tracking number of the fulfillment. */
+  number?: Maybe<Scalars['String']>,
+  /** The URL to track the fulfillment. */
+  url?: Maybe<Scalars['URL']>,
+};
+
+/** Represents information about the metafields associated to the specified resource. */
+export type HasMetafields = {
+  /** The metafield associated with the resource. */
+  metafield?: Maybe<Metafield>,
+  /** A paginated list of metafields associated with the resource. */
+  metafields: MetafieldConnection,
+};
+
+
+/** Represents information about the metafields associated to the specified resource. */
+export type HasMetafieldsMetafieldArgs = {
+  namespace: Scalars['String'],
+  key: Scalars['String']
+};
+
+
+/** Represents information about the metafields associated to the specified resource. */
+export type HasMetafieldsMetafieldsArgs = {
+  namespace?: Maybe<Scalars['String']>,
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** Represents an image resource. */
+export type Image = {
+   __typename?: 'Image',
+  /** A word or phrase to share the nature or contents of an image. */
+  altText?: Maybe<Scalars['String']>,
+  /** A unique identifier for the image. */
+  id?: Maybe<Scalars['ID']>,
+  /** 
+ * The location of the original image as a URL.
+   * 
+   * If there are any existing transformations in the original source URL, they will remain and not be stripped.
+ **/
+  originalSrc: Scalars['URL'],
+  /** The location of the image as a URL. */
+  src: Scalars['URL'],
+  /** 
+ * The location of the transformed image as a URL.
+   * 
+   * All transformation arguments are considered "best-effort". If they can be applied to an image, they will be.
+   * Otherwise any transformations which an image type does not support will be ignored.
+ **/
+  transformedSrc: Scalars['URL'],
+};
+
+
+/** Represents an image resource. */
+export type ImageTransformedSrcArgs = {
+  maxWidth?: Maybe<Scalars['Int']>,
+  maxHeight?: Maybe<Scalars['Int']>,
+  crop?: Maybe<CropRegion>,
+  scale?: Maybe<Scalars['Int']>,
+  preferredContentType?: Maybe<ImageContentType>
+};
+
+export type ImageConnection = {
+   __typename?: 'ImageConnection',
+  /** A list of edges. */
+  edges: Array<ImageEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+/** List of supported image content types. */
+export enum ImageContentType {
+  Png = 'PNG',
+  Jpg = 'JPG',
+  Webp = 'WEBP'
+}
+
+export type ImageEdge = {
+   __typename?: 'ImageEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of ImageEdge. */
+  node: Image,
+};
+
+/** Represents a mailing address for customers and shipping. */
+export type MailingAddress = Node & {
+   __typename?: 'MailingAddress',
+  /** The first line of the address. Typically the street address or PO Box number. */
+  address1?: Maybe<Scalars['String']>,
+  /** The second line of the address. Typically the number of the apartment, suite, or unit. */
+  address2?: Maybe<Scalars['String']>,
+  /** The name of the city, district, village, or town. */
+  city?: Maybe<Scalars['String']>,
+  /** The name of the customer's company or organization. */
+  company?: Maybe<Scalars['String']>,
+  /** The name of the country. */
+  country?: Maybe<Scalars['String']>,
+  /** 
+ * The two-letter code for the country of the address.
+   * 
+   * For example, US.
+ **/
+  countryCode?: Maybe<Scalars['String']>,
+  /** 
+ * The two-letter code for the country of the address.
+   * 
+   * For example, US.
+ **/
+  countryCodeV2?: Maybe<CountryCode>,
+  /** The first name of the customer. */
+  firstName?: Maybe<Scalars['String']>,
+  /** A formatted version of the address, customized by the provided arguments. */
+  formatted: Array<Scalars['String']>,
+  /** A comma-separated list of the values for city, province, and country. */
+  formattedArea?: Maybe<Scalars['String']>,
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** The last name of the customer. */
+  lastName?: Maybe<Scalars['String']>,
+  /** The latitude coordinate of the customer address. */
+  latitude?: Maybe<Scalars['Float']>,
+  /** The longitude coordinate of the customer address. */
+  longitude?: Maybe<Scalars['Float']>,
+  /** The full name of the customer, based on firstName and lastName. */
+  name?: Maybe<Scalars['String']>,
+  /** 
+ * A unique phone number for the customer.
+   * 
+   * Formatted using E.164 standard. For example, _+16135551111_.
+ **/
+  phone?: Maybe<Scalars['String']>,
+  /** The region of the address, such as the province, state, or district. */
+  province?: Maybe<Scalars['String']>,
+  /** 
+ * The two-letter code for the region.
+   * 
+   * For example, ON.
+ **/
+  provinceCode?: Maybe<Scalars['String']>,
+  /** The zip or postal code of the address. */
+  zip?: Maybe<Scalars['String']>,
+};
+
+
+/** Represents a mailing address for customers and shipping. */
+export type MailingAddressFormattedArgs = {
+  withName?: Maybe<Scalars['Boolean']>,
+  withCompany?: Maybe<Scalars['Boolean']>
+};
+
+export type MailingAddressConnection = {
+   __typename?: 'MailingAddressConnection',
+  /** A list of edges. */
+  edges: Array<MailingAddressEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type MailingAddressEdge = {
+   __typename?: 'MailingAddressEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of MailingAddressEdge. */
+  node: MailingAddress,
+};
+
+/** Specifies the fields accepted to create or update a mailing address. */
+export type MailingAddressInput = {
+  address1?: Maybe<Scalars['String']>,
+  address2?: Maybe<Scalars['String']>,
+  city?: Maybe<Scalars['String']>,
+  company?: Maybe<Scalars['String']>,
+  country?: Maybe<Scalars['String']>,
+  firstName?: Maybe<Scalars['String']>,
+  lastName?: Maybe<Scalars['String']>,
+  phone?: Maybe<Scalars['String']>,
+  province?: Maybe<Scalars['String']>,
+  zip?: Maybe<Scalars['String']>,
+};
+
+/** Manual discount applications capture the intentions of a discount that was manually created. */
+export type ManualDiscountApplication = DiscountApplication & {
+   __typename?: 'ManualDiscountApplication',
+  /** The method by which the discount's value is allocated to its entitled items. */
+  allocationMethod: DiscountApplicationAllocationMethod,
+  /** The description of the application. */
+  description?: Maybe<Scalars['String']>,
+  /** Which lines of targetType that the discount is allocated over. */
+  targetSelection: DiscountApplicationTargetSelection,
+  /** The type of line that the discount is applicable towards. */
+  targetType: DiscountApplicationTargetType,
+  /** The title of the application. */
+  title: Scalars['String'],
+  /** The value of the discount application. */
+  value: PricingValue,
+};
+
+/** 
+ * Metafields represent custom metadata attached to a resource. Metafields can be sorted into namespaces and are
+ * comprised of keys, values, and value types.
+ **/
+export type Metafield = Node & {
+   __typename?: 'Metafield',
+  /** The description of a metafield. */
+  description?: Maybe<Scalars['String']>,
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** The key name for a metafield. */
+  key: Scalars['String'],
+  /** The namespace for a metafield. */
+  namespace: Scalars['String'],
+  /** The parent object that the metafield belongs to. */
+  parentResource: MetafieldParentResource,
+  /** The value of a metafield. */
+  value: Scalars['String'],
+  /** Represents the metafield value type. */
+  valueType: MetafieldValueType,
+};
+
+export type MetafieldConnection = {
+   __typename?: 'MetafieldConnection',
+  /** A list of edges. */
+  edges: Array<MetafieldEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type MetafieldEdge = {
+   __typename?: 'MetafieldEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of MetafieldEdge. */
+  node: Metafield,
+};
+
+/** A resource that the metafield belongs to. */
+export type MetafieldParentResource = Product | ProductVariant;
+
+/** Metafield value types. */
+export enum MetafieldValueType {
+  /** A string metafield. */
+  String = 'STRING',
+  /** An integer metafield. */
+  Integer = 'INTEGER',
+  /** A json string metafield. */
+  JsonString = 'JSON_STRING'
+}
+
+
+/** Specifies the fields for a monetary value with currency. */
+export type MoneyInput = {
+  /** Decimal money amount. */
+  amount: Scalars['Decimal'],
+  /** Currency of the money. */
+  currencyCode: CurrencyCode,
+};
+
+/** 
+ * A monetary value with currency.
+ * 
+ * To format currencies, combine this type's amount and currencyCode fields with your client's locale.
+ * 
+ * For example, in JavaScript you could use Intl.NumberFormat:
+ * 
+ * ```js
+ * new Intl.NumberFormat(locale, {
+ *   style: 'currency',
+ *   currency: currencyCode
+ * }).format(amount);
+ * ```
+ * 
+ * Other formatting libraries include:
+ * 
+ * * iOS - [NumberFormatter](https://developer.apple.com/documentation/foundation/numberformatter)
+ * * Android - [NumberFormat](https://developer.android.com/reference/java/text/NumberFormat.html)
+ * * PHP - [NumberFormatter](http://php.net/manual/en/class.numberformatter.php)
+ * 
+ * For a more general solution, the [Unicode CLDR number formatting database] is available with many implementations
+ * (such as [TwitterCldr](https://github.com/twitter/twitter-cldr-rb)).
+ **/
+export type MoneyV2 = {
+   __typename?: 'MoneyV2',
+  /** Decimal money amount. */
+  amount: Scalars['Decimal'],
+  /** Currency of the money. */
+  currencyCode: CurrencyCode,
+};
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type Mutation = {
+   __typename?: 'Mutation',
+  /** Updates the attributes of a checkout. */
+  checkoutAttributesUpdate?: Maybe<CheckoutAttributesUpdatePayload>,
+  /** Updates the attributes of a checkout. */
+  checkoutAttributesUpdateV2?: Maybe<CheckoutAttributesUpdateV2Payload>,
+  /** 
+ * Completes a checkout without providing payment information. You can use this
+   * mutation for free items or items whose purchase price is covered by a gift card.
+ **/
+  checkoutCompleteFree?: Maybe<CheckoutCompleteFreePayload>,
+  /** Completes a checkout using a credit card token from Shopify's Vault. */
+  checkoutCompleteWithCreditCard?: Maybe<CheckoutCompleteWithCreditCardPayload>,
+  /** 
+ * Completes a checkout using a credit card token from Shopify's card vault.
+   * Before you can complete checkouts using CheckoutCompleteWithCreditCardV2, you
+   * need to  [_request payment processing_](https://help.shopify.com/api/guides/sales-channel-sdk/getting-started#request-payment-processing).
+ **/
+  checkoutCompleteWithCreditCardV2?: Maybe<CheckoutCompleteWithCreditCardV2Payload>,
+  /** Completes a checkout with a tokenized payment. */
+  checkoutCompleteWithTokenizedPayment?: Maybe<CheckoutCompleteWithTokenizedPaymentPayload>,
+  /** Completes a checkout with a tokenized payment. */
+  checkoutCompleteWithTokenizedPaymentV2?: Maybe<CheckoutCompleteWithTokenizedPaymentV2Payload>,
+  /** Creates a new checkout. */
+  checkoutCreate?: Maybe<CheckoutCreatePayload>,
+  /** Associates a customer to the checkout. */
+  checkoutCustomerAssociate?: Maybe<CheckoutCustomerAssociatePayload>,
+  /** Associates a customer to the checkout. */
+  checkoutCustomerAssociateV2?: Maybe<CheckoutCustomerAssociateV2Payload>,
+  /** Disassociates the current checkout customer from the checkout. */
+  checkoutCustomerDisassociate?: Maybe<CheckoutCustomerDisassociatePayload>,
+  /** Disassociates the current checkout customer from the checkout. */
+  checkoutCustomerDisassociateV2?: Maybe<CheckoutCustomerDisassociateV2Payload>,
+  /** Applies a discount to an existing checkout using a discount code. */
+  checkoutDiscountCodeApply?: Maybe<CheckoutDiscountCodeApplyPayload>,
+  /** Applies a discount to an existing checkout using a discount code. */
+  checkoutDiscountCodeApplyV2?: Maybe<CheckoutDiscountCodeApplyV2Payload>,
+  /** Removes the applied discount from an existing checkout. */
+  checkoutDiscountCodeRemove?: Maybe<CheckoutDiscountCodeRemovePayload>,
+  /** Updates the email on an existing checkout. */
+  checkoutEmailUpdate?: Maybe<CheckoutEmailUpdatePayload>,
+  /** Updates the email on an existing checkout. */
+  checkoutEmailUpdateV2?: Maybe<CheckoutEmailUpdateV2Payload>,
+  /** Applies a gift card to an existing checkout using a gift card code. This will replace all currently applied gift cards. */
+  checkoutGiftCardApply?: Maybe<CheckoutGiftCardApplyPayload>,
+  /** Removes an applied gift card from the checkout. */
+  checkoutGiftCardRemove?: Maybe<CheckoutGiftCardRemovePayload>,
+  /** Removes an applied gift card from the checkout. */
+  checkoutGiftCardRemoveV2?: Maybe<CheckoutGiftCardRemoveV2Payload>,
+  /** Appends gift cards to an existing checkout. */
+  checkoutGiftCardsAppend?: Maybe<CheckoutGiftCardsAppendPayload>,
+  /** Adds a list of line items to a checkout. */
+  checkoutLineItemsAdd?: Maybe<CheckoutLineItemsAddPayload>,
+  /** Removes line items from an existing checkout */
+  checkoutLineItemsRemove?: Maybe<CheckoutLineItemsRemovePayload>,
+  /** Sets a list of line items to a checkout. */
+  checkoutLineItemsReplace?: Maybe<CheckoutLineItemsReplacePayload>,
+  /** Updates line items on a checkout. */
+  checkoutLineItemsUpdate?: Maybe<CheckoutLineItemsUpdatePayload>,
+  /** Updates the shipping address of an existing checkout. */
+  checkoutShippingAddressUpdate?: Maybe<CheckoutShippingAddressUpdatePayload>,
+  /** Updates the shipping address of an existing checkout. */
+  checkoutShippingAddressUpdateV2?: Maybe<CheckoutShippingAddressUpdateV2Payload>,
+  /** Updates the shipping lines on an existing checkout. */
+  checkoutShippingLineUpdate?: Maybe<CheckoutShippingLineUpdatePayload>,
+  /** 
+ * Creates a customer access token.
+   * The customer access token is required to modify the customer object in any way.
+ **/
+  customerAccessTokenCreate?: Maybe<CustomerAccessTokenCreatePayload>,
+  /** Permanently destroys a customer access token. */
+  customerAccessTokenDelete?: Maybe<CustomerAccessTokenDeletePayload>,
+  /** 
+ * Renews a customer access token.
+   * 
+   * Access token renewal must happen *before* a token expires.
+   * If a token has already expired, a new one should be created instead via `customerAccessTokenCreate`.
+ **/
+  customerAccessTokenRenew?: Maybe<CustomerAccessTokenRenewPayload>,
+  /** Activates a customer. */
+  customerActivate?: Maybe<CustomerActivatePayload>,
+  /** Creates a new address for a customer. */
+  customerAddressCreate?: Maybe<CustomerAddressCreatePayload>,
+  /** Permanently deletes the address of an existing customer. */
+  customerAddressDelete?: Maybe<CustomerAddressDeletePayload>,
+  /** Updates the address of an existing customer. */
+  customerAddressUpdate?: Maybe<CustomerAddressUpdatePayload>,
+  /** Creates a new customer. */
+  customerCreate?: Maybe<CustomerCreatePayload>,
+  /** Updates the default address of an existing customer. */
+  customerDefaultAddressUpdate?: Maybe<CustomerDefaultAddressUpdatePayload>,
+  /** Sends a reset password email to the customer, as the first step in the reset password process. */
+  customerRecover?: Maybe<CustomerRecoverPayload>,
+  /** Resets a customer’s password with a token received from `CustomerRecover`. */
+  customerReset?: Maybe<CustomerResetPayload>,
+  /** Resets a customer’s password with the reset password url received from `CustomerRecover`. */
+  customerResetByUrl?: Maybe<CustomerResetByUrlPayload>,
+  /** Updates an existing customer. */
+  customerUpdate?: Maybe<CustomerUpdatePayload>,
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutAttributesUpdateArgs = {
+  checkoutId: Scalars['ID'],
+  input: CheckoutAttributesUpdateInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutAttributesUpdateV2Args = {
+  checkoutId: Scalars['ID'],
+  input: CheckoutAttributesUpdateV2Input
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCompleteFreeArgs = {
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCompleteWithCreditCardArgs = {
+  checkoutId: Scalars['ID'],
+  payment: CreditCardPaymentInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCompleteWithCreditCardV2Args = {
+  checkoutId: Scalars['ID'],
+  payment: CreditCardPaymentInputV2
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCompleteWithTokenizedPaymentArgs = {
+  checkoutId: Scalars['ID'],
+  payment: TokenizedPaymentInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCompleteWithTokenizedPaymentV2Args = {
+  checkoutId: Scalars['ID'],
+  payment: TokenizedPaymentInputV2
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCreateArgs = {
+  input: CheckoutCreateInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCustomerAssociateArgs = {
+  checkoutId: Scalars['ID'],
+  customerAccessToken: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCustomerAssociateV2Args = {
+  checkoutId: Scalars['ID'],
+  customerAccessToken: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCustomerDisassociateArgs = {
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutCustomerDisassociateV2Args = {
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutDiscountCodeApplyArgs = {
+  discountCode: Scalars['String'],
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutDiscountCodeApplyV2Args = {
+  discountCode: Scalars['String'],
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutDiscountCodeRemoveArgs = {
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutEmailUpdateArgs = {
+  checkoutId: Scalars['ID'],
+  email: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutEmailUpdateV2Args = {
+  checkoutId: Scalars['ID'],
+  email: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutGiftCardApplyArgs = {
+  giftCardCode: Scalars['String'],
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutGiftCardRemoveArgs = {
+  appliedGiftCardId: Scalars['ID'],
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutGiftCardRemoveV2Args = {
+  appliedGiftCardId: Scalars['ID'],
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutGiftCardsAppendArgs = {
+  giftCardCodes: Array<Scalars['String']>,
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutLineItemsAddArgs = {
+  lineItems: Array<CheckoutLineItemInput>,
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutLineItemsRemoveArgs = {
+  checkoutId: Scalars['ID'],
+  lineItemIds: Array<Scalars['ID']>
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutLineItemsReplaceArgs = {
+  lineItems: Array<CheckoutLineItemInput>,
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutLineItemsUpdateArgs = {
+  checkoutId: Scalars['ID'],
+  lineItems: Array<CheckoutLineItemUpdateInput>
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutShippingAddressUpdateArgs = {
+  shippingAddress: MailingAddressInput,
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutShippingAddressUpdateV2Args = {
+  shippingAddress: MailingAddressInput,
+  checkoutId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCheckoutShippingLineUpdateArgs = {
+  checkoutId: Scalars['ID'],
+  shippingRateHandle: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerAccessTokenCreateArgs = {
+  input: CustomerAccessTokenCreateInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerAccessTokenDeleteArgs = {
+  customerAccessToken: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerAccessTokenRenewArgs = {
+  customerAccessToken: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerActivateArgs = {
+  id: Scalars['ID'],
+  input: CustomerActivateInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerAddressCreateArgs = {
+  customerAccessToken: Scalars['String'],
+  address: MailingAddressInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerAddressDeleteArgs = {
+  id: Scalars['ID'],
+  customerAccessToken: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerAddressUpdateArgs = {
+  customerAccessToken: Scalars['String'],
+  id: Scalars['ID'],
+  address: MailingAddressInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerCreateArgs = {
+  input: CustomerCreateInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerDefaultAddressUpdateArgs = {
+  customerAccessToken: Scalars['String'],
+  addressId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerRecoverArgs = {
+  email: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerResetArgs = {
+  id: Scalars['ID'],
+  input: CustomerResetInput
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerResetByUrlArgs = {
+  resetUrl: Scalars['URL'],
+  password: Scalars['String']
+};
+
+
+/** The schema’s entry-point for mutations. This acts as the public, top-level API from which all mutation queries must start. */
+export type MutationCustomerUpdateArgs = {
+  customerAccessToken: Scalars['String'],
+  customer: CustomerUpdateInput
+};
+
+/** An object with an ID to support global identification. */
+export type Node = {
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+};
+
+/** 
+ * An order is a customer’s completed request to purchase one or more products from
+ * a shop. An order is created when a customer completes the checkout process,
+ * during which time they provides an email address, billing address and payment information.
+ **/
+export type Order = Node & {
+   __typename?: 'Order',
+  /** The code of the currency used for the payment. */
+  currencyCode: CurrencyCode,
+  /** The locale code in which this specific order happened. */
+  customerLocale?: Maybe<Scalars['String']>,
+  /** The unique URL that the customer can use to access the order. */
+  customerUrl?: Maybe<Scalars['URL']>,
+  /** Discounts that have been applied on the order. */
+  discountApplications: DiscountApplicationConnection,
+  /** The customer's email address. */
+  email?: Maybe<Scalars['String']>,
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** List of the order’s line items. */
+  lineItems: OrderLineItemConnection,
+  /** 
+ * Unique identifier for the order that appears on the order.
+   * For example, _#1000_ or _Store1001.
+ **/
+  name: Scalars['String'],
+  /** A unique numeric identifier for the order for use by shop owner and customer. */
+  orderNumber: Scalars['Int'],
+  /** The customer's phone number for receiving SMS notifications. */
+  phone?: Maybe<Scalars['String']>,
+  /** 
+ * The date and time when the order was imported.
+   * This value can be set to dates in the past when importing from other systems.
+   * If no value is provided, it will be auto-generated based on current date and time.
+ **/
+  processedAt: Scalars['DateTime'],
+  /** The address to where the order will be shipped. */
+  shippingAddress?: Maybe<MailingAddress>,
+  /** The discounts that have been allocated onto the shipping line by discount applications. */
+  shippingDiscountAllocations: Array<DiscountAllocation>,
+  /** The unique URL for the order's status page. */
+  statusUrl: Scalars['URL'],
+  /** Price of the order before shipping and taxes. */
+  subtotalPrice?: Maybe<Scalars['Money']>,
+  /** Price of the order before shipping and taxes. */
+  subtotalPriceV2?: Maybe<MoneyV2>,
+  /** List of the order’s successful fulfillments. */
+  successfulFulfillments?: Maybe<Array<Fulfillment>>,
+  /** The sum of all the prices of all the items in the order, taxes and discounts included (must be positive). */
+  totalPrice: Scalars['Money'],
+  /** The sum of all the prices of all the items in the order, taxes and discounts included (must be positive). */
+  totalPriceV2: MoneyV2,
+  /** The total amount that has been refunded. */
+  totalRefunded: Scalars['Money'],
+  /** The total amount that has been refunded. */
+  totalRefundedV2: MoneyV2,
+  /** The total cost of shipping. */
+  totalShippingPrice: Scalars['Money'],
+  /** The total cost of shipping. */
+  totalShippingPriceV2: MoneyV2,
+  /** The total cost of taxes. */
+  totalTax?: Maybe<Scalars['Money']>,
+  /** The total cost of taxes. */
+  totalTaxV2?: Maybe<MoneyV2>,
+};
+
+
+/** 
+ * An order is a customer’s completed request to purchase one or more products from
+ * a shop. An order is created when a customer completes the checkout process,
+ * during which time they provides an email address, billing address and payment information.
+ **/
+export type OrderDiscountApplicationsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** 
+ * An order is a customer’s completed request to purchase one or more products from
+ * a shop. An order is created when a customer completes the checkout process,
+ * during which time they provides an email address, billing address and payment information.
+ **/
+export type OrderLineItemsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** 
+ * An order is a customer’s completed request to purchase one or more products from
+ * a shop. An order is created when a customer completes the checkout process,
+ * during which time they provides an email address, billing address and payment information.
+ **/
+export type OrderSuccessfulFulfillmentsArgs = {
+  first?: Maybe<Scalars['Int']>
+};
+
+export type OrderConnection = {
+   __typename?: 'OrderConnection',
+  /** A list of edges. */
+  edges: Array<OrderEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type OrderEdge = {
+   __typename?: 'OrderEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of OrderEdge. */
+  node: Order,
+};
+
+/** Represents a single line in an order. There is one line item for each distinct product variant. */
+export type OrderLineItem = {
+   __typename?: 'OrderLineItem',
+  /** List of custom attributes associated to the line item. */
+  customAttributes: Array<Attribute>,
+  /** The discounts that have been allocated onto the order line item by discount applications. */
+  discountAllocations: Array<DiscountAllocation>,
+  /** The number of products variants associated to the line item. */
+  quantity: Scalars['Int'],
+  /** The title of the product combined with title of the variant. */
+  title: Scalars['String'],
+  /** The product variant object associated to the line item. */
+  variant?: Maybe<ProductVariant>,
+};
+
+export type OrderLineItemConnection = {
+   __typename?: 'OrderLineItemConnection',
+  /** A list of edges. */
+  edges: Array<OrderLineItemEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type OrderLineItemEdge = {
+   __typename?: 'OrderLineItemEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of OrderLineItemEdge. */
+  node: OrderLineItem,
+};
+
+/** The set of valid sort keys for the orders query. */
+export enum OrderSortKeys {
+  /** Sort by the `processed_at` value. */
+  ProcessedAt = 'PROCESSED_AT',
+  /** Sort by the `total_price` value. */
+  TotalPrice = 'TOTAL_PRICE',
+  /** Sort by the `id` value. */
+  Id = 'ID',
+  /** 
+ * During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the
+   * results by relevance to the search term(s). When no search query is specified, this sort key is not
+   * deterministic and should not be used.
+ **/
+  Relevance = 'RELEVANCE'
+}
+
+/** 
+ * Shopify merchants can create pages to hold static HTML content. Each Page object
+ * represents a custom page on the online store.
+ **/
+export type Page = Node & {
+   __typename?: 'Page',
+  /** The description of the page, complete with HTML formatting. */
+  body: Scalars['HTML'],
+  /** Summary of the page body. */
+  bodySummary: Scalars['String'],
+  /** The timestamp of the page creation. */
+  createdAt: Scalars['DateTime'],
+  /** A human-friendly unique string for the page automatically generated from its title. */
+  handle: Scalars['String'],
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** The title of the page. */
+  title: Scalars['String'],
+  /** The timestamp of the latest page update. */
+  updatedAt: Scalars['DateTime'],
+  /** The url pointing to the page accessible from the web. */
+  url: Scalars['URL'],
+};
+
+export type PageConnection = {
+   __typename?: 'PageConnection',
+  /** A list of edges. */
+  edges: Array<PageEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type PageEdge = {
+   __typename?: 'PageEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of PageEdge. */
+  node: Page,
+};
+
+/** Information about pagination in a connection. */
+export type PageInfo = {
+   __typename?: 'PageInfo',
+  /** Indicates if there are more pages to fetch. */
+  hasNextPage: Scalars['Boolean'],
+  /** Indicates if there are any pages prior to the current page. */
+  hasPreviousPage: Scalars['Boolean'],
+};
+
+/** The set of valid sort keys for the pages query. */
+export enum PageSortKeys {
+  /** Sort by the `title` value. */
+  Title = 'TITLE',
+  /** Sort by the `updated_at` value. */
+  UpdatedAt = 'UPDATED_AT',
+  /** Sort by the `id` value. */
+  Id = 'ID',
+  /** 
+ * During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the
+   * results by relevance to the search term(s). When no search query is specified, this sort key is not
+   * deterministic and should not be used.
+ **/
+  Relevance = 'RELEVANCE'
+}
+
+/** A payment applied to a checkout. */
+export type Payment = Node & {
+   __typename?: 'Payment',
+  /** The amount of the payment. */
+  amount: Scalars['Money'],
+  /** The amount of the payment. */
+  amountV2: MoneyV2,
+  /** The billing address for the payment. */
+  billingAddress?: Maybe<MailingAddress>,
+  /** The checkout to which the payment belongs. */
+  checkout: Checkout,
+  /** The credit card used for the payment in the case of direct payments. */
+  creditCard?: Maybe<CreditCard>,
+  /** A message describing a processing error during asynchronous processing. */
+  errorMessage?: Maybe<Scalars['String']>,
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** A client-side generated token to identify a payment and perform idempotent operations. */
+  idempotencyKey?: Maybe<Scalars['String']>,
+  /** The URL where the customer needs to be redirected so they can complete the 3D Secure payment flow. */
+  nextActionUrl?: Maybe<Scalars['URL']>,
+  /** Whether or not the payment is still processing asynchronously. */
+  ready: Scalars['Boolean'],
+  /** A flag to indicate if the payment is to be done in test mode for gateways that support it. */
+  test: Scalars['Boolean'],
+  /** The actual transaction recorded by Shopify after having processed the payment with the gateway. */
+  transaction?: Maybe<Transaction>,
+};
+
+/** Settings related to payments. */
+export type PaymentSettings = {
+   __typename?: 'PaymentSettings',
+  /** List of the card brands which the shop accepts. */
+  acceptedCardBrands: Array<CardBrand>,
+  /** The url pointing to the endpoint to vault credit cards. */
+  cardVaultUrl: Scalars['URL'],
+  /** The country where the shop is located. */
+  countryCode: CountryCode,
+  /** The three-letter code for the shop's primary currency. */
+  currencyCode: CurrencyCode,
+  /** 
+ * A list of enabled currencies (ISO 4217 format) that the shop accepts.
+   * Merchants can enable currencies from their Shopify Payments settings in the Shopify admin.
+ **/
+  enabledPresentmentCurrencies: Array<CurrencyCode>,
+  /** The shop’s Shopify Payments account id. */
+  shopifyPaymentsAccountId?: Maybe<Scalars['String']>,
+  /** List of the digital wallets which the shop supports. */
+  supportedDigitalWallets: Array<DigitalWallet>,
+};
+
+/** The value of the percentage pricing object. */
+export type PricingPercentageValue = {
+   __typename?: 'PricingPercentageValue',
+  /** The percentage value of the object. */
+  percentage: Scalars['Float'],
+};
+
+/** The price value (fixed or percentage) for a discount application. */
+export type PricingValue = PricingPercentageValue | MoneyV2;
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type Product = Node & HasMetafields & {
+   __typename?: 'Product',
+  /** Indicates if at least one product variant is available for sale. */
+  availableForSale: Scalars['Boolean'],
+  /** List of collections a product belongs to. */
+  collections: CollectionConnection,
+  /** The date and time when the product was created. */
+  createdAt: Scalars['DateTime'],
+  /** Stripped description of the product, single line with HTML tags removed. */
+  description: Scalars['String'],
+  /** The description of the product, complete with HTML formatting. */
+  descriptionHtml: Scalars['HTML'],
+  /** 
+ * A human-friendly unique string for the Product automatically generated from its title.
+   * They are used by the Liquid templating language to refer to objects.
+ **/
+  handle: Scalars['String'],
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** List of images associated with the product. */
+  images: ImageConnection,
+  /** The metafield associated with the resource. */
+  metafield?: Maybe<Metafield>,
+  /** A paginated list of metafields associated with the resource. */
+  metafields: MetafieldConnection,
+  /** 
+ * The online store URL for the product.
+   * A value of `null` indicates that the product is not published to the Online Store sales channel.
+ **/
+  onlineStoreUrl?: Maybe<Scalars['URL']>,
+  /** List of custom product options (maximum of 3 per product). */
+  options: Array<ProductOption>,
+  /** List of price ranges in the presentment currencies for this shop. */
+  presentmentPriceRanges: ProductPriceRangeConnection,
+  /** The price range. */
+  priceRange: ProductPriceRange,
+  /** A categorization that a product can be tagged with, commonly used for filtering and searching. */
+  productType: Scalars['String'],
+  /** The date and time when the product was published to the channel. */
+  publishedAt: Scalars['DateTime'],
+  /** 
+ * A categorization that a product can be tagged with, commonly used for filtering and searching.
+   * Additional access scope required for private apps: unauthenticated_read_product_tags.
+ **/
+  tags: Array<Scalars['String']>,
+  /** The product’s title. */
+  title: Scalars['String'],
+  /** The date and time when the product was last modified. */
+  updatedAt: Scalars['DateTime'],
+  /** 
+ * Find a product’s variant based on its selected options.
+   * This is useful for converting a user’s selection of product options into a single matching variant.
+   * If there is not a variant for the selected options, `null` will be returned.
+ **/
+  variantBySelectedOptions?: Maybe<ProductVariant>,
+  /** List of the product’s variants. */
+  variants: ProductVariantConnection,
+  /** The product’s vendor name. */
+  vendor: Scalars['String'],
+};
+
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type ProductCollectionsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type ProductDescriptionArgs = {
+  truncateAt?: Maybe<Scalars['Int']>
+};
+
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type ProductImagesArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<ProductImageSortKeys>,
+  maxWidth?: Maybe<Scalars['Int']>,
+  maxHeight?: Maybe<Scalars['Int']>,
+  crop?: Maybe<CropRegion>,
+  scale?: Maybe<Scalars['Int']>
+};
+
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type ProductMetafieldArgs = {
+  namespace: Scalars['String'],
+  key: Scalars['String']
+};
+
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type ProductMetafieldsArgs = {
+  namespace?: Maybe<Scalars['String']>,
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type ProductOptionsArgs = {
+  first?: Maybe<Scalars['Int']>
+};
+
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type ProductPresentmentPriceRangesArgs = {
+  presentmentCurrencies?: Maybe<Array<CurrencyCode>>,
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type ProductVariantBySelectedOptionsArgs = {
+  selectedOptions: Array<SelectedOptionInput>
+};
+
+
+/** 
+ * A product represents an individual item for sale in a Shopify store. Products are often physical, but they don't have to be.
+ * For example, a digital download (such as a movie, music or ebook file) also
+ * qualifies as a product, as do services (such as equipment rental, work for hire,
+ * customization of another product or an extended warranty).
+ **/
+export type ProductVariantsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<ProductVariantSortKeys>
+};
+
+/** The set of valid sort keys for the products query. */
+export enum ProductCollectionSortKeys {
+  /** Sort by the `title` value. */
+  Title = 'TITLE',
+  /** Sort by the `price` value. */
+  Price = 'PRICE',
+  /** Sort by the `best-selling` value. */
+  BestSelling = 'BEST_SELLING',
+  /** Sort by the `created` value. */
+  Created = 'CREATED',
+  /** Sort by the `id` value. */
+  Id = 'ID',
+  /** Sort by the `manual` value. */
+  Manual = 'MANUAL',
+  /** Sort by the `collection-default` value. */
+  CollectionDefault = 'COLLECTION_DEFAULT',
+  /** 
+ * During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the
+   * results by relevance to the search term(s). When no search query is specified, this sort key is not
+   * deterministic and should not be used.
+ **/
+  Relevance = 'RELEVANCE'
+}
+
+export type ProductConnection = {
+   __typename?: 'ProductConnection',
+  /** A list of edges. */
+  edges: Array<ProductEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type ProductEdge = {
+   __typename?: 'ProductEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of ProductEdge. */
+  node: Product,
+};
+
+/** The set of valid sort keys for the images query. */
+export enum ProductImageSortKeys {
+  /** Sort by the `created_at` value. */
+  CreatedAt = 'CREATED_AT',
+  /** Sort by the `position` value. */
+  Position = 'POSITION',
+  /** Sort by the `id` value. */
+  Id = 'ID',
+  /** 
+ * During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the
+   * results by relevance to the search term(s). When no search query is specified, this sort key is not
+   * deterministic and should not be used.
+ **/
+  Relevance = 'RELEVANCE'
+}
+
+/** 
+ * Custom product property names like "Size", "Color", and "Material".
+ * Products are based on permutations of these options.
+ * A product may have a maximum of 3 options.
+ * 255 characters limit each.
+ **/
+export type ProductOption = Node & {
+   __typename?: 'ProductOption',
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** The product option’s name. */
+  name: Scalars['String'],
+  /** The corresponding value to the product option name. */
+  values: Array<Scalars['String']>,
+};
+
+/** The price range of the product. */
+export type ProductPriceRange = {
+   __typename?: 'ProductPriceRange',
+  /** The highest variant's price. */
+  maxVariantPrice: MoneyV2,
+  /** The lowest variant's price. */
+  minVariantPrice: MoneyV2,
+};
+
+export type ProductPriceRangeConnection = {
+   __typename?: 'ProductPriceRangeConnection',
+  /** A list of edges. */
+  edges: Array<ProductPriceRangeEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type ProductPriceRangeEdge = {
+   __typename?: 'ProductPriceRangeEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of ProductPriceRangeEdge. */
+  node: ProductPriceRange,
+};
+
+/** The set of valid sort keys for the products query. */
+export enum ProductSortKeys {
+  /** Sort by the `title` value. */
+  Title = 'TITLE',
+  /** Sort by the `product_type` value. */
+  ProductType = 'PRODUCT_TYPE',
+  /** Sort by the `vendor` value. */
+  Vendor = 'VENDOR',
+  /** Sort by the `updated_at` value. */
+  UpdatedAt = 'UPDATED_AT',
+  /** Sort by the `created_at` value. */
+  CreatedAt = 'CREATED_AT',
+  /** Sort by the `best_selling` value. */
+  BestSelling = 'BEST_SELLING',
+  /** Sort by the `price` value. */
+  Price = 'PRICE',
+  /** Sort by the `id` value. */
+  Id = 'ID',
+  /** 
+ * During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the
+   * results by relevance to the search term(s). When no search query is specified, this sort key is not
+   * deterministic and should not be used.
+ **/
+  Relevance = 'RELEVANCE'
+}
+
+/** A product variant represents a different version of a product, such as differing sizes or differing colors. */
+export type ProductVariant = Node & HasMetafields & {
+   __typename?: 'ProductVariant',
+  /** Indicates if the product variant is in stock. */
+  available?: Maybe<Scalars['Boolean']>,
+  /** Indicates if the product variant is available for sale. */
+  availableForSale: Scalars['Boolean'],
+  /** 
+ * The compare at price of the variant. This can be used to mark a variant as on
+   * sale, when `compareAtPrice` is higher than `price`.
+ **/
+  compareAtPrice?: Maybe<Scalars['Money']>,
+  /** 
+ * The compare at price of the variant. This can be used to mark a variant as on
+   * sale, when `compareAtPriceV2` is higher than `priceV2`.
+ **/
+  compareAtPriceV2?: Maybe<MoneyV2>,
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** Image associated with the product variant. This field falls back to the product image if no image is available. */
+  image?: Maybe<Image>,
+  /** The metafield associated with the resource. */
+  metafield?: Maybe<Metafield>,
+  /** A paginated list of metafields associated with the resource. */
+  metafields: MetafieldConnection,
+  /** List of prices and compare-at prices in the presentment currencies for this shop. */
+  presentmentPrices: ProductVariantPricePairConnection,
+  /** The product variant’s price. */
+  price: Scalars['Money'],
+  /** The product variant’s price. */
+  priceV2: MoneyV2,
+  /** The product object that the product variant belongs to. */
+  product: Product,
+  /** Whether a customer needs to provide a shipping address when placing an order for the product variant. */
+  requiresShipping: Scalars['Boolean'],
+  /** List of product options applied to the variant. */
+  selectedOptions: Array<SelectedOption>,
+  /** The SKU (stock keeping unit) associated with the variant. */
+  sku?: Maybe<Scalars['String']>,
+  /** The product variant’s title. */
+  title: Scalars['String'],
+  /** The weight of the product variant in the unit system specified with `weight_unit`. */
+  weight?: Maybe<Scalars['Float']>,
+  /** Unit of measurement for weight. */
+  weightUnit: WeightUnit,
+};
+
+
+/** A product variant represents a different version of a product, such as differing sizes or differing colors. */
+export type ProductVariantImageArgs = {
+  maxWidth?: Maybe<Scalars['Int']>,
+  maxHeight?: Maybe<Scalars['Int']>,
+  crop?: Maybe<CropRegion>,
+  scale?: Maybe<Scalars['Int']>
+};
+
+
+/** A product variant represents a different version of a product, such as differing sizes or differing colors. */
+export type ProductVariantMetafieldArgs = {
+  namespace: Scalars['String'],
+  key: Scalars['String']
+};
+
+
+/** A product variant represents a different version of a product, such as differing sizes or differing colors. */
+export type ProductVariantMetafieldsArgs = {
+  namespace?: Maybe<Scalars['String']>,
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+
+/** A product variant represents a different version of a product, such as differing sizes or differing colors. */
+export type ProductVariantPresentmentPricesArgs = {
+  presentmentCurrencies?: Maybe<Array<CurrencyCode>>,
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>
+};
+
+export type ProductVariantConnection = {
+   __typename?: 'ProductVariantConnection',
+  /** A list of edges. */
+  edges: Array<ProductVariantEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type ProductVariantEdge = {
+   __typename?: 'ProductVariantEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of ProductVariantEdge. */
+  node: ProductVariant,
+};
+
+/** The compare-at price and price of a variant sharing a currency. */
+export type ProductVariantPricePair = {
+   __typename?: 'ProductVariantPricePair',
+  /** The compare-at price of the variant with associated currency. */
+  compareAtPrice?: Maybe<MoneyV2>,
+  /** The price of the variant with associated currency. */
+  price: MoneyV2,
+};
+
+export type ProductVariantPricePairConnection = {
+   __typename?: 'ProductVariantPricePairConnection',
+  /** A list of edges. */
+  edges: Array<ProductVariantPricePairEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type ProductVariantPricePairEdge = {
+   __typename?: 'ProductVariantPricePairEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of ProductVariantPricePairEdge. */
+  node: ProductVariantPricePair,
+};
+
+/** The set of valid sort keys for the variants query. */
+export enum ProductVariantSortKeys {
+  /** Sort by the `title` value. */
+  Title = 'TITLE',
+  /** Sort by the `sku` value. */
+  Sku = 'SKU',
+  /** Sort by the `position` value. */
+  Position = 'POSITION',
+  /** Sort by the `id` value. */
+  Id = 'ID',
+  /** 
+ * During a search (i.e. when the `query` parameter has been specified on the connection) this sorts the
+   * results by relevance to the search term(s). When no search query is specified, this sort key is not
+   * deterministic and should not be used.
+ **/
+  Relevance = 'RELEVANCE'
+}
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRoot = {
+   __typename?: 'QueryRoot',
+  /** List of the shop's articles. */
+  articles: ArticleConnection,
+  /** Find a blog by its handle. */
+  blogByHandle?: Maybe<Blog>,
+  /** List of the shop's blogs. */
+  blogs: BlogConnection,
+  /** Find a collection by its handle. */
+  collectionByHandle?: Maybe<Collection>,
+  /** List of the shop’s collections. */
+  collections: CollectionConnection,
+  customer?: Maybe<Customer>,
+  node?: Maybe<Node>,
+  nodes: Array<Maybe<Node>>,
+  /** Find a page by its handle. */
+  pageByHandle?: Maybe<Page>,
+  /** List of the shop's pages. */
+  pages: PageConnection,
+  /** Find a product by its handle. */
+  productByHandle?: Maybe<Product>,
+  /** 
+ * Find recommended products related to a given `product_id`.
+   * To learn more about how recommendations are generated, see
+   * [*Showing product recommendations on product pages*](https://help.shopify.com/themes/development/recommended-products).
+ **/
+  productRecommendations?: Maybe<Array<Product>>,
+  /** 
+ * Tags added to products.
+   * Additional access scope required: unauthenticated_read_product_tags.
+ **/
+  productTags: StringConnection,
+  /** List of product types for the shop's products that are published to your app. */
+  productTypes: StringConnection,
+  /** List of the shop’s products. */
+  products: ProductConnection,
+  /** The list of public Storefront API versions, including supported, release candidate and unstable versions. */
+  publicApiVersions: Array<ApiVersion>,
+  shop: Shop,
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootArticlesArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<ArticleSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootBlogByHandleArgs = {
+  handle: Scalars['String']
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootBlogsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<BlogSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootCollectionByHandleArgs = {
+  handle: Scalars['String']
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootCollectionsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<CollectionSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootCustomerArgs = {
+  customerAccessToken: Scalars['String']
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootNodeArgs = {
+  id: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootNodesArgs = {
+  ids: Array<Scalars['ID']>
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootPageByHandleArgs = {
+  handle: Scalars['String']
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootPagesArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<PageSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootProductByHandleArgs = {
+  handle: Scalars['String']
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootProductRecommendationsArgs = {
+  productId: Scalars['ID']
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootProductTagsArgs = {
+  first: Scalars['Int']
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootProductTypesArgs = {
+  first: Scalars['Int']
+};
+
+
+/** The schema’s entry-point for queries. This acts as the public, top-level API from which all queries must start. */
+export type QueryRootProductsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<ProductSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+/** 
+ * Script discount applications capture the intentions of a discount that
+ * was created by a Shopify Script.
+ **/
+export type ScriptDiscountApplication = DiscountApplication & {
+   __typename?: 'ScriptDiscountApplication',
+  /** The method by which the discount's value is allocated to its entitled items. */
+  allocationMethod: DiscountApplicationAllocationMethod,
+  /** The description of the application as defined by the Script. */
+  description: Scalars['String'],
+  /** Which lines of targetType that the discount is allocated over. */
+  targetSelection: DiscountApplicationTargetSelection,
+  /** The type of line that the discount is applicable towards. */
+  targetType: DiscountApplicationTargetType,
+  /** The title of the application as defined by the Script. */
+  title: Scalars['String'],
+  /** The value of the discount application. */
+  value: PricingValue,
+};
+
+/** 
+ * Custom properties that a shop owner can use to define product variants.
+ * Multiple options can exist. Options are represented as: option1, option2, option3, etc.
+ **/
+export type SelectedOption = {
+   __typename?: 'SelectedOption',
+  /** The product option’s name. */
+  name: Scalars['String'],
+  /** The product option’s value. */
+  value: Scalars['String'],
+};
+
+/** Specifies the input fields required for a selected option. */
+export type SelectedOptionInput = {
+  /** The product option’s name. */
+  name: Scalars['String'],
+  /** The product option’s value. */
+  value: Scalars['String'],
+};
+
+/** SEO information. */
+export type Seo = {
+   __typename?: 'SEO',
+  /** The meta description. */
+  description?: Maybe<Scalars['String']>,
+  /** The SEO title. */
+  title?: Maybe<Scalars['String']>,
+};
+
+/** A shipping rate to be applied to a checkout. */
+export type ShippingRate = {
+   __typename?: 'ShippingRate',
+  /** Human-readable unique identifier for this shipping rate. */
+  handle: Scalars['String'],
+  /** Price of this shipping rate. */
+  price: Scalars['Money'],
+  /** Price of this shipping rate. */
+  priceV2: MoneyV2,
+  /** Title of this shipping rate. */
+  title: Scalars['String'],
+};
+
+/** Shop represents a collection of the general settings and information about the shop. */
+export type Shop = {
+   __typename?: 'Shop',
+  /** List of the shop' articles. */
+  articles: ArticleConnection,
+  /** List of the shop' blogs. */
+  blogs: BlogConnection,
+  /** Find a collection by its handle. */
+  collectionByHandle?: Maybe<Collection>,
+  /** List of the shop’s collections. */
+  collections: CollectionConnection,
+  /** The three-letter code for the currency that the shop accepts. */
+  currencyCode: CurrencyCode,
+  /** A description of the shop. */
+  description?: Maybe<Scalars['String']>,
+  /** A string representing the way currency is formatted when the currency isn’t specified. */
+  moneyFormat: Scalars['String'],
+  /** The shop’s name. */
+  name: Scalars['String'],
+  /** Settings related to payments. */
+  paymentSettings: PaymentSettings,
+  /** The shop’s primary domain. */
+  primaryDomain: Domain,
+  /** The shop’s privacy policy. */
+  privacyPolicy?: Maybe<ShopPolicy>,
+  /** Find a product by its handle. */
+  productByHandle?: Maybe<Product>,
+  /** 
+ * Tags added to products.
+   * Additional access scope required: unauthenticated_read_product_tags.
+ **/
+  productTags: StringConnection,
+  /** List of the shop’s product types. */
+  productTypes: StringConnection,
+  /** List of the shop’s products. */
+  products: ProductConnection,
+  /** The shop’s refund policy. */
+  refundPolicy?: Maybe<ShopPolicy>,
+  /** Countries that the shop ships to. */
+  shipsToCountries: Array<CountryCode>,
+  /** The shop’s Shopify Payments account id. */
+  shopifyPaymentsAccountId?: Maybe<Scalars['String']>,
+  /** The shop’s terms of service. */
+  termsOfService?: Maybe<ShopPolicy>,
+};
+
+
+/** Shop represents a collection of the general settings and information about the shop. */
+export type ShopArticlesArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<ArticleSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+
+/** Shop represents a collection of the general settings and information about the shop. */
+export type ShopBlogsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<BlogSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+
+/** Shop represents a collection of the general settings and information about the shop. */
+export type ShopCollectionByHandleArgs = {
+  handle: Scalars['String']
+};
+
+
+/** Shop represents a collection of the general settings and information about the shop. */
+export type ShopCollectionsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<CollectionSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+
+/** Shop represents a collection of the general settings and information about the shop. */
+export type ShopProductByHandleArgs = {
+  handle: Scalars['String']
+};
+
+
+/** Shop represents a collection of the general settings and information about the shop. */
+export type ShopProductTagsArgs = {
+  first: Scalars['Int']
+};
+
+
+/** Shop represents a collection of the general settings and information about the shop. */
+export type ShopProductTypesArgs = {
+  first: Scalars['Int']
+};
+
+
+/** Shop represents a collection of the general settings and information about the shop. */
+export type ShopProductsArgs = {
+  first?: Maybe<Scalars['Int']>,
+  after?: Maybe<Scalars['String']>,
+  last?: Maybe<Scalars['Int']>,
+  before?: Maybe<Scalars['String']>,
+  reverse?: Maybe<Scalars['Boolean']>,
+  sortKey?: Maybe<ProductSortKeys>,
+  query?: Maybe<Scalars['String']>
+};
+
+/** Policy that a merchant has configured for their store, such as their refund or privacy policy. */
+export type ShopPolicy = Node & {
+   __typename?: 'ShopPolicy',
+  /** Policy text, maximum size of 64kb. */
+  body: Scalars['String'],
+  /** Policy’s handle. */
+  handle: Scalars['String'],
+  /** Globally unique identifier. */
+  id: Scalars['ID'],
+  /** Policy’s title. */
+  title: Scalars['String'],
+  /** Public URL to the policy. */
+  url: Scalars['URL'],
+};
+
+export type StringConnection = {
+   __typename?: 'StringConnection',
+  /** A list of edges. */
+  edges: Array<StringEdge>,
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo,
+};
+
+export type StringEdge = {
+   __typename?: 'StringEdge',
+  /** A cursor for use in pagination. */
+  cursor: Scalars['String'],
+  /** The item at the end of StringEdge. */
+  node: Scalars['String'],
+};
+
+/** 
+ * Specifies the fields required to complete a checkout with
+ * a tokenized payment.
+ **/
+export type TokenizedPaymentInput = {
+  /** The amount of the payment. */
+  amount: Scalars['Money'],
+  /** 
+ * A unique client generated key used to avoid duplicate charges. When a
+   * duplicate payment is found, the original is returned instead of creating a new one.
+ **/
+  idempotencyKey: Scalars['String'],
+  /** The billing address for the payment. */
+  billingAddress: MailingAddressInput,
+  /** The type of payment token. */
+  type: Scalars['String'],
+  /** A simple string or JSON containing the required payment data for the tokenized payment. */
+  paymentData: Scalars['String'],
+  /** Executes the payment in test mode if possible. Defaults to `false`. */
+  test?: Maybe<Scalars['Boolean']>,
+  /** Public Hash Key used for AndroidPay payments only. */
+  identifier?: Maybe<Scalars['String']>,
+};
+
+/** 
+ * Specifies the fields required to complete a checkout with
+ * a tokenized payment.
+ **/
+export type TokenizedPaymentInputV2 = {
+  /** The amount and currency of the payment. */
+  paymentAmount: MoneyInput,
+  /** 
+ * A unique client generated key used to avoid duplicate charges. When a
+   * duplicate payment is found, the original is returned instead of creating a new one.
+ **/
+  idempotencyKey: Scalars['String'],
+  /** The billing address for the payment. */
+  billingAddress: MailingAddressInput,
+  /** The type of payment token. */
+  type: Scalars['String'],
+  /** A simple string or JSON containing the required payment data for the tokenized payment. */
+  paymentData: Scalars['String'],
+  /** Executes the payment in test mode if possible. Defaults to `false`. */
+  test?: Maybe<Scalars['Boolean']>,
+  /** Public Hash Key used for AndroidPay payments only. */
+  identifier?: Maybe<Scalars['String']>,
+};
+
+/** An object representing exchange of money for a product or service. */
+export type Transaction = {
+   __typename?: 'Transaction',
+  /** The amount of money that the transaction was for. */
+  amount: Scalars['Money'],
+  /** The amount of money that the transaction was for. */
+  amountV2: MoneyV2,
+  /** The kind of the transaction. */
+  kind: TransactionKind,
+  /** The status of the transaction. */
+  status: TransactionStatus,
+  /** The status of the transaction. */
+  statusV2?: Maybe<TransactionStatus>,
+  /** Whether the transaction was done in test mode or not. */
+  test: Scalars['Boolean'],
+};
+
+export enum TransactionKind {
+  Sale = 'SALE',
+  Capture = 'CAPTURE',
+  Authorization = 'AUTHORIZATION',
+  EmvAuthorization = 'EMV_AUTHORIZATION',
+  Change = 'CHANGE'
+}
+
+export enum TransactionStatus {
+  Pending = 'PENDING',
+  Success = 'SUCCESS',
+  Failure = 'FAILURE',
+  Error = 'ERROR'
+}
+
+
+/** Represents an error in the input of a mutation. */
+export type UserError = DisplayableError & {
+   __typename?: 'UserError',
+  /** Path to the input field which caused the error. */
+  field?: Maybe<Array<Scalars['String']>>,
+  /** The error message. */
+  message: Scalars['String'],
+};
+
+/** Units of measurement for weight. */
+export enum WeightUnit {
+  /** 1 kilogram equals 1000 grams. */
+  Kilograms = 'KILOGRAMS',
+  /** Metric system unit of mass. */
+  Grams = 'GRAMS',
+  /** 1 pound equals 16 ounces. */
+  Pounds = 'POUNDS',
+  /** Imperial system unit of mass. */
+  Ounces = 'OUNCES'
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,29 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.7.0.tgz",
+      "integrity": "sha512-LSln3cexwInTMYYoFeVLKnYPPMfWNJ8PubTBs3hkh7wCu9iBaqq1OOyW+xGmEdLxT1nhsl+9SJ+h2oUDYz0l2A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.7.0",
+        "esutils": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
+          "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-call-delegate": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
@@ -345,6 +368,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz",
+      "integrity": "sha512-UxYaGXYQ7rrKJS/PxIKRkv3exi05oH7rokBAsmCSsCxz1sVPZ7Fu6FzKoGgUvmY+0YgSkYHgUoCh5R5bCNBQlw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-decorators": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
@@ -357,6 +389,15 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
       "integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.7.0.tgz",
+      "integrity": "sha512-vQMV07p+L+jZeUnvX3pEJ9EiXGCjB5CTTvsirFD9rpEuATnoAvLBLoYbw1v5tyn3d2XxSuvEKi8cV3KqYUa0vQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -486,6 +527,16 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.6.3.tgz",
+      "integrity": "sha512-l0ETkyEofkqFJ9LS6HChNIKtVJw2ylKbhYMlJ5C6df+ldxxaLIyXY4yOdDQQspfFpV8/vDiaWoJlvflstlYNxg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.2.0"
+      }
+    },
     "@babel/plugin-transform-for-of": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.4.tgz",
@@ -600,6 +651,26 @@
       "integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-react-display-name": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
+      "integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.7.0.tgz",
+      "integrity": "sha512-mXhBtyVB1Ujfy+0L6934jeJcSXj/VCg6whZzEcgiiZHNS0PGC7vUCsZDQCxxztkpIdF+dY1fUMcjAgEOC3ZOMQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "^7.7.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
       }
     },
     "@babel/plugin-transform-regenerator": {
@@ -801,6 +872,306 @@
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
+    "@graphql-codegen/cli": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/cli/-/cli-1.8.3.tgz",
+      "integrity": "sha512-TAFc6jQ9TRlXGKfj50xE4u6zHJyvWFlBsSyurNDp9nREK36iNOhFazW55CE3z5PcHPn4OC/tpn3YZzrPtYGhuQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "7.6.4",
+        "@graphql-codegen/core": "1.8.3",
+        "@graphql-codegen/plugin-helpers": "1.8.3",
+        "@graphql-toolkit/code-file-loader": "0.6.6",
+        "@graphql-toolkit/core": "0.6.6",
+        "@graphql-toolkit/git-loader": "0.6.6",
+        "@graphql-toolkit/github-loader": "0.6.6",
+        "@graphql-toolkit/graphql-file-loader": "0.6.6",
+        "@graphql-toolkit/json-file-loader": "0.6.6",
+        "@graphql-toolkit/url-loader": "0.6.6",
+        "@types/debounce": "1.2.0",
+        "@types/is-glob": "4.0.1",
+        "@types/mkdirp": "0.5.2",
+        "@types/valid-url": "1.0.2",
+        "babel-types": "7.0.0-beta.3",
+        "chalk": "2.4.2",
+        "change-case": "3.1.0",
+        "chokidar": "3.3.0",
+        "commander": "4.0.0",
+        "common-tags": "1.8.0",
+        "cosmiconfig": "5.2.1",
+        "debounce": "1.2.0",
+        "detect-indent": "6.0.0",
+        "glob": "7.1.5",
+        "graphql-config": "3.0.0-alpha.14",
+        "graphql-import": "0.7.1",
+        "graphql-tag-pluck": "0.8.7",
+        "graphql-tools": "4.0.6",
+        "indent-string": "4.0.0",
+        "inquirer": "7.0.0",
+        "is-glob": "4.0.1",
+        "is-valid-path": "0.1.1",
+        "json-to-pretty-yaml": "1.2.2",
+        "listr": "0.14.3",
+        "listr-update-renderer": "0.5.0",
+        "log-symbols": "3.0.0",
+        "log-update": "3.3.0",
+        "mkdirp": "0.5.1",
+        "prettier": "1.18.2",
+        "request": "2.88.0",
+        "ts-log": "2.1.4",
+        "tslib": "1.10.0",
+        "valid-url": "1.0.9"
+      },
+      "dependencies": {
+        "babel-types": {
+          "version": "7.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-7.0.0-beta.3.tgz",
+          "integrity": "sha512-36k8J+byAe181OmCMawGhw+DtKO7AwexPVtsPXoMfAkjtZgoCX3bEuHWfdE5sYxRM8dojvtG/+O08M0Z/YDC6w==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.2.0",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "chokidar": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+          "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.2.0"
+          }
+        },
+        "commander": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.0.tgz",
+          "integrity": "sha512-SEa2abMBTZuEjLVYpNrAFoRgxPwG4rXP3+SGY6CM/HZGeDzIA7Pzp+7H3AHDukKEpyy2SoSGGPShKqqfH9T9AQ==",
+          "dev": true
+        },
+        "detect-indent": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+          "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
+          "dev": true
+        },
+        "prettier": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+          "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/core": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-1.8.3.tgz",
+      "integrity": "sha512-JZ2YHnxpS44VqCSjROO8lXQ/bxAaqCHn2RxDHsSc1Zg0fSTIAF9f/N3bphYoez5d/5R7zoB50ZEyeqXeLg0esw==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.8.3",
+        "@graphql-toolkit/common": "0.6.6",
+        "@graphql-toolkit/schema-merging": "0.6.6",
+        "tslib": "1.10.0"
+      }
+    },
+    "@graphql-codegen/plugin-helpers": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.8.3.tgz",
+      "integrity": "sha512-4/wYWtnOSsY4QSRfNrnaMm+hqqjz0e3LV6KG8t2ajDyebYR9UvHUlzvpdfSj+Gptw6k3/PgJLNdtf8Y0fbjTng==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.6",
+        "change-case": "3.1.0",
+        "common-tags": "1.8.0",
+        "import-from": "3.0.0",
+        "tslib": "1.10.0"
+      },
+      "dependencies": {
+        "import-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+          "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+          "dev": true,
+          "requires": {
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-codegen/typescript": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-1.8.3.tgz",
+      "integrity": "sha512-Hw8b/iu/ZEAK22G3YmU//98jfmYN835ZPAx3w4c/reeMv4syfAoUlXrSKCbvfi/TOzVRzK/FjYKa0h5dKMoyPA==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.8.3",
+        "@graphql-codegen/visitor-plugin-common": "1.8.3",
+        "auto-bind": "3.0.0",
+        "tslib": "1.10.0"
+      }
+    },
+    "@graphql-codegen/visitor-plugin-common": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.8.3.tgz",
+      "integrity": "sha512-Qsh0xh7IpdKZ87moHxeHTTQUD6JD0z3GVbgLWRgkWRpgWciQHs1M+06UGtb32b/YhfQcPG4JfnyJhwiKMNfbjw==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "1.8.3",
+        "auto-bind": "3.0.0",
+        "dependency-graph": "0.8.0",
+        "graphql-tag": "2.10.1",
+        "relay-compiler": "6.0.0",
+        "tslib": "1.10.0"
+      }
+    },
+    "@graphql-toolkit/code-file-loader": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/code-file-loader/-/code-file-loader-0.6.6.tgz",
+      "integrity": "sha512-c+esssFwiREtRFi/sPkOyNiRWb2N+3N294RH73+JyDUzh2dNBpP4omM5N9AN2vmIxU+XYbS6fhQ85mAuZ3ANbw==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.6",
+        "graphql-tag-pluck": "0.8.6"
+      },
+      "dependencies": {
+        "graphql-tag-pluck": {
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/graphql-tag-pluck/-/graphql-tag-pluck-0.8.6.tgz",
+          "integrity": "sha512-j5ftGv++G5cccwsQ1M6G907c7RffBWiWu0OVkxWVc2I+8BR2LuWziEUMTcT2K9/lWl43NeM0SDIsW+RUO6W2qQ==",
+          "dev": true,
+          "requires": {
+            "@babel/parser": "^7.4.4",
+            "@babel/traverse": "^7.4.4",
+            "@babel/types": "^7.4.4",
+            "source-map-support": "^0.5.12"
+          }
+        }
+      }
+    },
+    "@graphql-toolkit/common": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/common/-/common-0.6.6.tgz",
+      "integrity": "sha512-6el8vYdtwO+LCZTfrpBsblsCYFFeUQ7W/KMGz2K/paE2V6mn93T0lzGkyGTSjxknqvqaTJOUMejzK719wAoQdQ==",
+      "dev": true,
+      "requires": {
+        "@kamilkisiela/graphql-tools": "4.0.6",
+        "aggregate-error": "3.0.1",
+        "lodash": "4.17.15"
+      }
+    },
+    "@graphql-toolkit/core": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/core/-/core-0.6.6.tgz",
+      "integrity": "sha512-qK8DHpG7c0kTflOnrYLOlNDh/Y8Eh7JtZVa6VrPeBfDDgC0+Khca7i+nPP13xLxtCetTISbiBxD0jj3mdw7+bg==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.6",
+        "@graphql-toolkit/schema-merging": "0.6.6",
+        "aggregate-error": "3.0.1",
+        "globby": "10.0.1",
+        "graphql-import": "0.7.1",
+        "is-glob": "4.0.1",
+        "is-valid-path": "0.1.1",
+        "tslib": "^1.9.3",
+        "valid-url": "1.0.9"
+      }
+    },
+    "@graphql-toolkit/git-loader": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/git-loader/-/git-loader-0.6.6.tgz",
+      "integrity": "sha512-vjsASLSWxOG4NUaKcdYgWQ6lEfB7eZQFOfoMCu8DrvaYI2Nb10pnCWfA+vb7Ay8Ezpc+DiAMvIVqIiWw7Osf2A==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.6",
+        "simple-git": "1.126.0"
+      }
+    },
+    "@graphql-toolkit/github-loader": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/github-loader/-/github-loader-0.6.6.tgz",
+      "integrity": "sha512-bVy2dbCE059tq8qP7wKHsxgWxsUS24C3LtCZS+79B66rWqkndCmb10Y2irCAIe4QniBUQ8kGD0rVZXS3fdsv/w==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.6",
+        "cross-fetch": "3.0.4"
+      }
+    },
+    "@graphql-toolkit/graphql-file-loader": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/graphql-file-loader/-/graphql-file-loader-0.6.6.tgz",
+      "integrity": "sha512-hpk+zVgf+UgAQLDbYQ3/Zz6hhUdzfRjKvKOpTSdLNOW7S5ptOB0B76SYHVsjClFjyphanLwx1UraZzjoU7/Dhg==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.6",
+        "graphql-import": "0.7.1"
+      }
+    },
+    "@graphql-toolkit/json-file-loader": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/json-file-loader/-/json-file-loader-0.6.6.tgz",
+      "integrity": "sha512-SpGAxnvI/sWReZRFixWMw5MP8RF8kH0LvDcLNmEINgSfV9OhhLO145j2i1SsnsZrMbE1niR8vz8iaLFvARZU7A==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.6"
+      }
+    },
+    "@graphql-toolkit/schema-merging": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/schema-merging/-/schema-merging-0.6.6.tgz",
+      "integrity": "sha512-vqwm9ya6gV7lFAF2/e84FpHcQMIpPJJbbFsrl4+9HXghoJEg1DXjZho4UJcB7ZVFR3ZDx2DkHhgX2TB/GWGg8A==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.6",
+        "@kamilkisiela/graphql-tools": "4.0.6",
+        "deepmerge": "4.2.2"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+          "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+          "dev": true
+        }
+      }
+    },
+    "@graphql-toolkit/url-loader": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@graphql-toolkit/url-loader/-/url-loader-0.6.6.tgz",
+      "integrity": "sha512-0XKZyNX2d1v313PVFrZvLwGKk0ZCKKUVfsgtNLScP4p5K/4+dvCk0JKYFr5IBONoN5yonXApjJUzjZoTt6QC0g==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.6",
+        "cross-fetch": "3.0.4",
+        "valid-url": "1.0.9"
+      }
+    },
+    "@kamilkisiela/graphql-tools": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@kamilkisiela/graphql-tools/-/graphql-tools-4.0.6.tgz",
+      "integrity": "sha512-IPWa+dOFCE4zaCsrJrAMp7yWXnfOZLNhqoMEOmn958WkLM0mmsDc/W/Rh7/7xopIT6P0oizb6/N1iH5HnNXOUA==",
+      "dev": true,
+      "requires": {
+        "apollo-link": "^1.2.3",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
+      }
+    },
     "@kazupon/vue-i18n-loader": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@kazupon/vue-i18n-loader/-/vue-i18n-loader-0.4.1.tgz",
@@ -808,6 +1179,42 @@
       "requires": {
         "js-yaml": "^3.13.1",
         "json5": "^2.1.0"
+      }
+    },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
       }
     },
     "@nuxt/babel-preset-app": {
@@ -1197,6 +1604,15 @@
         "stack-trace": "0.0.10"
       }
     },
+    "@samverschueren/stream-to-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+      "dev": true,
+      "requires": {
+        "any-observable": "^0.3.0"
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -1272,6 +1688,12 @@
         "@types/node": "*"
       }
     },
+    "@types/debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1285,6 +1707,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
     },
     "@types/express": {
       "version": "4.17.2",
@@ -1305,6 +1733,17 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/html-minifier": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
@@ -1314,6 +1753,12 @@
         "@types/relateurl": "*",
         "@types/uglify-js": "*"
       }
+    },
+    "@types/is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-k3RS5HyBPu4h+5hTmIEfPB2rl5P3LnGdQEZrV2b9OWTJVtsUQ2VBcedqYKGqxvZqle5UALUXdSfVA8nf3HfyWQ==",
+      "dev": true
     },
     "@types/json-schema": {
       "version": "7.0.3",
@@ -1339,6 +1784,21 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/mkdirp": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+      "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/node": {
       "version": "12.12.6",
@@ -1410,6 +1870,12 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
+    },
+    "@types/valid-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/valid-url/-/valid-url-1.0.2.tgz",
+      "integrity": "sha1-YPpDXOJL/VuhB7jSqAeWrq86j0U=",
+      "dev": true
     },
     "@types/webpack": {
       "version": "4.39.8",
@@ -1889,6 +2355,15 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wry/equality": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.1.9.tgz",
+      "integrity": "sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -2022,6 +2497,12 @@
         "color-convert": "^1.9.0"
       }
     },
+    "any-observable": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+      "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+      "dev": true
+    },
     "anymatch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -2029,6 +2510,30 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "apollo-link": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.13.tgz",
+      "integrity": "sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==",
+      "dev": true,
+      "requires": {
+        "apollo-utilities": "^1.3.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3",
+        "zen-observable-ts": "^0.8.20"
+      }
+    },
+    "apollo-utilities": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.3.2.tgz",
+      "integrity": "sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==",
+      "dev": true,
+      "requires": {
+        "@wry/equality": "^0.1.2",
+        "fast-json-stable-stringify": "^2.0.0",
+        "ts-invariant": "^0.4.0",
+        "tslib": "^1.9.3"
       }
     },
     "aproba": {
@@ -2121,10 +2626,22 @@
         "es-abstract": "^1.7.0"
       }
     },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -2212,6 +2729,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+    },
+    "auto-bind": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-3.0.0.tgz",
+      "integrity": "sha512-v0A231a/lfOo6kxQtmEkdBfTApvC21aJYukA8pkKnoTvVqh3Wmm7/Rwy4GBCHTTHVoLVA5qsBDDvf1XY1nIV2g==",
+      "dev": true
     },
     "autoprefixer": {
       "version": "9.6.5",
@@ -2316,6 +2839,47 @@
       "integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
       "requires": {
         "object.assign": "^4.1.0"
+      }
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz",
+      "integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==",
+      "dev": true
+    },
+    "babel-preset-fbjs": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz",
+      "integrity": "sha512-7QTLTCd2gwB2qGoi5epSULMHugSVgpcVt5YAeiFO9ABLrutDQzKfGwzxgZHLpugq8qMdg/DhRZDZ5CLKxBkEbw==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+        "@babel/plugin-syntax-class-properties": "^7.0.0",
+        "@babel/plugin-syntax-flow": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.0.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoped-functions": "^7.0.0",
+        "@babel/plugin-transform-block-scoping": "^7.0.0",
+        "@babel/plugin-transform-classes": "^7.0.0",
+        "@babel/plugin-transform-computed-properties": "^7.0.0",
+        "@babel/plugin-transform-destructuring": "^7.0.0",
+        "@babel/plugin-transform-flow-strip-types": "^7.0.0",
+        "@babel/plugin-transform-for-of": "^7.0.0",
+        "@babel/plugin-transform-function-name": "^7.0.0",
+        "@babel/plugin-transform-literals": "^7.0.0",
+        "@babel/plugin-transform-member-expression-literals": "^7.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.0.0",
+        "@babel/plugin-transform-object-super": "^7.0.0",
+        "@babel/plugin-transform-parameters": "^7.0.0",
+        "@babel/plugin-transform-property-literals": "^7.0.0",
+        "@babel/plugin-transform-react-display-name": "^7.0.0",
+        "@babel/plugin-transform-react-jsx": "^7.0.0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0",
+        "@babel/plugin-transform-spread": "^7.0.0",
+        "@babel/plugin-transform-template-literals": "^7.0.0",
+        "babel-plugin-syntax-trailing-function-commas": "^7.0.0-beta.0"
       }
     },
     "babel-runtime": {
@@ -2663,6 +3227,15 @@
         "node-releases": "^1.1.36"
       }
     },
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
@@ -2810,6 +3383,12 @@
         }
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "caller-callsite": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
@@ -2893,6 +3472,32 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
+      }
+    },
+    "change-case": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-3.1.0.tgz",
+      "integrity": "sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==",
+      "dev": true,
+      "requires": {
+        "camel-case": "^3.0.0",
+        "constant-case": "^2.0.0",
+        "dot-case": "^2.1.0",
+        "header-case": "^1.0.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "no-case": "^2.3.2",
+        "param-case": "^2.1.0",
+        "pascal-case": "^2.0.0",
+        "path-case": "^2.1.0",
+        "sentence-case": "^2.1.0",
+        "snake-case": "^2.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^2.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "chardet": {
@@ -3010,6 +3615,59 @@
       "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "cli-width": {
@@ -3157,6 +3815,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -3293,6 +3957,16 @@
         "bluebird": "^3.1.1"
       }
     },
+    "constant-case": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-2.0.0.tgz",
+      "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
+      "dev": true,
+      "requires": {
+        "snake-case": "^2.1.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -3415,6 +4089,16 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
       }
     },
     "cross-spawn": {
@@ -3688,6 +4372,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -3697,6 +4387,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
       "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
+    },
+    "debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg==",
+      "dev": true
     },
     "debug": {
       "version": "4.1.1",
@@ -3802,6 +4498,18 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "dependency-graph": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.8.0.tgz",
+      "integrity": "sha512-DCvzSq2UiMsuLnj/9AL484ummEgLtZIcRS7YvtO38QnpX3vqh9nJ8P+zhu8Ja+SmLrBHO2iDbva20jq38qvBkQ==",
+      "dev": true
+    },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
+      "dev": true
+    },
     "des.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -3842,6 +4550,23 @@
       "integrity": "sha512-r5Cb8jvJ9YOTKQje2wrD6ncjpyDM4l94+OqgatYNzTb0viKS0/XomCjty1+F827u1pBiPt1ubSYdowZfE1L5Tw==",
       "requires": {
         "rewrite-imports": "^2.0.3"
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        }
       }
     },
     "doctrine": {
@@ -3903,6 +4628,15 @@
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
+      }
+    },
+    "dot-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-2.1.1.tgz",
+      "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "dot-prop": {
@@ -3983,6 +4717,12 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.292.tgz",
       "integrity": "sha512-hqkem5ANpt6mxVXmhAmlbdG8iicuyM/jEYgmP1tiHPeOLyZoTyGUzrDmJS/xyrrZy9frkW1uQcubicu7f6DS5g=="
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "elliptic": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
@@ -4011,6 +4751,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "~0.4.13"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -4908,6 +5657,31 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
+    "fast-glob": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+      "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -4917,6 +5691,46 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fastq": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.0"
+      }
+    },
+    "fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
+      "requires": {
+        "bser": "^2.0.0"
+      }
+    },
+    "fbjs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-1.0.0.tgz",
+      "integrity": "sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.1",
+        "fbjs-css-vars": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.18"
+      }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
       "dev": true
     },
     "figgy-pudding": {
@@ -6099,6 +6913,12 @@
         "is-glob": "^4.0.1"
       }
     },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -6109,6 +6929,22 @@
       "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.4.tgz",
       "integrity": "sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==",
       "dev": true
+    },
+    "globby": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+      "integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      }
     },
     "globrex": {
       "version": "0.1.2",
@@ -6131,6 +6967,139 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+    },
+    "graphql": {
+      "version": "14.5.8",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.8.tgz",
+      "integrity": "sha512-MMwmi0zlVLQKLdGiMfWkgQD7dY/TUKt4L+zgJ/aR0Howebod3aNgP5JkgvAULiR2HPVZaP2VEElqtdidHweLkg==",
+      "dev": true,
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
+    "graphql-config": {
+      "version": "3.0.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-3.0.0-alpha.14.tgz",
+      "integrity": "sha512-1QprLsWSc28ip1tOEm9M0HDif73gSBV58LofzTrfjy2rBob1qqxIOX3aIaaAVEIMN90scNNCZmWwkhf70H1R3Q==",
+      "dev": true,
+      "requires": {
+        "@graphql-toolkit/common": "0.6.2",
+        "@graphql-toolkit/graphql-file-loader": "0.6.2",
+        "@graphql-toolkit/json-file-loader": "0.6.2",
+        "@graphql-toolkit/schema-merging": "0.6.2",
+        "@graphql-toolkit/url-loader": "0.6.2",
+        "cosmiconfig": "5.2.1",
+        "minimatch": "3.0.4"
+      },
+      "dependencies": {
+        "@graphql-toolkit/common": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-toolkit/common/-/common-0.6.2.tgz",
+          "integrity": "sha512-iwm9xzHvpa03lz/fdIJOyZS59nkMWMjAojyIOXv1qRVoyxgHg5UP4Fguo0F+rl/uW9KOtjypN9ljpz4f6KEMaw==",
+          "dev": true,
+          "requires": {
+            "@kamilkisiela/graphql-tools": "4.0.6",
+            "aggregate-error": "3.0.1",
+            "lodash": "4.17.15"
+          }
+        },
+        "@graphql-toolkit/graphql-file-loader": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-toolkit/graphql-file-loader/-/graphql-file-loader-0.6.2.tgz",
+          "integrity": "sha512-G1gkkNKjy3jflSNe7iShPsnx+rT4cx/jTHTL3eO1cGqYNlkpQbaray+O+ahR637MVio3KET2Xvv0p7opgosQ7w==",
+          "dev": true,
+          "requires": {
+            "@graphql-toolkit/common": "0.6.2",
+            "graphql-import": "0.7.1"
+          }
+        },
+        "@graphql-toolkit/json-file-loader": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-toolkit/json-file-loader/-/json-file-loader-0.6.2.tgz",
+          "integrity": "sha512-J/oac+QwwLZgjP7aWglFAaBpM3e06KjjbBrR/XOhMJhSwf2kzfWFBYrbYhx4IcxQPr9QqPLW18o1Rwbd3reUSw==",
+          "dev": true,
+          "requires": {
+            "@graphql-toolkit/common": "0.6.2"
+          }
+        },
+        "@graphql-toolkit/schema-merging": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-toolkit/schema-merging/-/schema-merging-0.6.2.tgz",
+          "integrity": "sha512-aiXNwEY6v9GVZJb821aQHIZyeAVVHcK39Sc/tB5ogY86qqDF0NX2pGLjgptwmKHW/S8lg+1WPXnG+A588bs4tw==",
+          "dev": true,
+          "requires": {
+            "@graphql-toolkit/common": "0.6.2",
+            "@kamilkisiela/graphql-tools": "4.0.6",
+            "deepmerge": "4.2.0"
+          }
+        },
+        "@graphql-toolkit/url-loader": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/@graphql-toolkit/url-loader/-/url-loader-0.6.2.tgz",
+          "integrity": "sha512-mdCp7OwT7EzCt2i+6uyO6fjocPy+gHorf/juls6oKVNcKXgSdk/EKkuLHqmBnx4zQZwbQfzcSXHjQ9YBse9U1A==",
+          "dev": true,
+          "requires": {
+            "@graphql-toolkit/common": "0.6.2",
+            "cross-fetch": "3.0.4",
+            "valid-url": "1.0.9"
+          }
+        },
+        "deepmerge": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.0.tgz",
+          "integrity": "sha512-/pED+kD8V9n15L1lon8DXEiWLQMW4tTiegn1kIWIQ+DBudOkFitz1cfjWQiSeKMPBQOknT3LpueyAmMVJ1Ho2g==",
+          "dev": true
+        }
+      }
+    },
+    "graphql-import": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz",
+      "integrity": "sha512-YpwpaPjRUVlw2SN3OPljpWbVRWAhMAyfSba5U47qGMOSsPLi2gYeJtngGpymjm9nk57RFWEpjqwh4+dpYuFAPw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
+    "graphql-tag": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.10.1.tgz",
+      "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==",
+      "dev": true
+    },
+    "graphql-tag-pluck": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/graphql-tag-pluck/-/graphql-tag-pluck-0.8.7.tgz",
+      "integrity": "sha512-yuWcQislvBPHorFQzmZ9/yY0nPD1rn1kBNOr6iPXzT+iJ/i/pciq8Z7ilnVJAGKaJXV58ovD+AWWYYjX6IFF9g==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "source-map-support": "^0.5.12"
+      }
+    },
+    "graphql-tools": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.6.tgz",
+      "integrity": "sha512-jHLQw8x3xmSNRBCsaZqelXXsFfUSUSktSCUP8KYHiX1Z9qEuwcMpAf+FkdBzk8aTAFqOlPdNZ3OI4DKKqGKUqg==",
+      "dev": true,
+      "requires": {
+        "apollo-link": "^1.2.3",
+        "apollo-utilities": "^1.0.1",
+        "deprecated-decorator": "^0.1.6",
+        "iterall": "^1.1.3",
+        "uuid": "^3.1.0"
+      }
     },
     "gzip-size": {
       "version": "5.1.1",
@@ -6302,6 +7271,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+    },
+    "header-case": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/header-case/-/header-case-1.0.1.tgz",
+      "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.3"
+      }
     },
     "hex-color-regex": {
       "version": "1.1.0",
@@ -6528,6 +7507,12 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
       "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+    },
+    "immutable": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
+      "integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks=",
+      "dev": true
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -6786,6 +7771,41 @@
       "resolved": "https://registry.npmjs.org/is-https/-/is-https-1.0.0.tgz",
       "integrity": "sha512-1adLLwZT9XEXjzhQhZxd75uxf0l+xI9uTSFaZeSESjL3E1eXSPpO+u5RcgqtzeZ1KCaNvtEwZSTO2P4U5erVqQ=="
     },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.0"
+      }
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6795,6 +7815,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-observable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+      "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "^1.1.0"
+      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -6854,11 +7883,29 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.0"
+      }
+    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
+    },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "dev": true,
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -6885,10 +7932,44 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
+      }
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "iterall": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+      "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==",
       "dev": true
     },
     "jest-worker": {
@@ -6979,6 +8060,16 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
+    "json-to-pretty-yaml": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
+      "integrity": "sha1-9M0L0KXo/h3yWq9boRiwmf2ZLVs=",
+      "dev": true,
+      "requires": {
+        "remedial": "^1.0.7",
+        "remove-trailing-spaces": "^1.0.6"
+      }
+    },
     "json5": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
@@ -7055,6 +8146,288 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "listr": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+      "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+      "dev": true,
+      "requires": {
+        "@samverschueren/stream-to-observable": "^0.3.0",
+        "is-observable": "^1.1.0",
+        "is-promise": "^2.1.0",
+        "is-stream": "^1.1.0",
+        "listr-silent-renderer": "^1.1.1",
+        "listr-update-renderer": "^0.5.0",
+        "listr-verbose-renderer": "^0.5.0",
+        "p-map": "^2.0.0",
+        "rxjs": "^6.3.3"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "cli-truncate": "^0.2.1",
+        "elegant-spinner": "^1.0.1",
+        "figures": "^1.7.0",
+        "indent-string": "^3.0.0",
+        "log-symbols": "^1.0.2",
+        "log-update": "^2.3.0",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
+          }
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.0.0"
+          }
+        },
+        "log-update": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+          "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "cli-cursor": "^2.0.0",
+            "wrap-ansi": "^3.0.1"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "cli-cursor": "^2.1.0",
+        "date-fns": "^1.27.2",
+        "figures": "^2.0.0"
+      },
+      "dependencies": {
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        }
       }
     },
     "load-json-file": {
@@ -7266,6 +8639,90 @@
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
     },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
+    "log-update": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.3.0.tgz",
+      "integrity": "sha512-YSKm5n+YjZoGZT5lfmOqasVH1fIH9xQA9A81Y48nZ99PxAP62vdCCtua+Gcu6oTn0nqtZd/LwRV+Vflo53ZDWA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "cli-cursor": "^2.1.0",
+        "wrap-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        }
+      }
+    },
     "loglevel": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
@@ -7293,6 +8750,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.2"
+      }
     },
     "lru-cache": {
       "version": "5.1.1",
@@ -7366,6 +8832,23 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        }
+      }
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -7532,6 +9015,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+    },
+    "merge2": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "dev": true
     },
     "methods": {
       "version": "1.1.2",
@@ -7910,6 +9399,12 @@
         }
       }
     },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
     "node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -8169,6 +9664,12 @@
       "requires": {
         "boolbase": "~1.0.0"
       }
+    },
+    "nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "dev": true
     },
     "num2fraction": {
       "version": "1.2.2",
@@ -8560,6 +10061,16 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "pascal-case": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-2.0.1.tgz",
+      "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
+      "dev": true,
+      "requires": {
+        "camel-case": "^3.0.0",
+        "upper-case-first": "^1.1.0"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -8569,6 +10080,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+    },
+    "path-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-2.1.1.tgz",
+      "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -9698,6 +11218,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -10077,10 +11606,282 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
+    "relay-compiler": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-6.0.0.tgz",
+      "integrity": "sha512-8K8cCwrOTqu3usF8GXQ+JEgxcTxJ5qVFqfNpfMYrRpMraXrBmykcLRpj38p2MxtcjyqkE2ZnUe5huW5/469obA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "babel-preset-fbjs": "^3.1.2",
+        "chalk": "^2.4.1",
+        "fast-glob": "^2.2.2",
+        "fb-watchman": "^2.0.0",
+        "fbjs": "^1.0.0",
+        "immutable": "~3.7.6",
+        "nullthrows": "^1.1.0",
+        "relay-runtime": "6.0.0",
+        "signedsource": "^1.0.0",
+        "yargs": "^9.0.0"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+          "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+          "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+          "dev": true,
+          "requires": {
+            "@mrmlnc/readdir-enhanced": "^2.2.1",
+            "@nodelib/fs.stat": "^1.1.2",
+            "glob-parent": "^3.1.0",
+            "is-glob": "^4.0.0",
+            "merge2": "^1.2.3",
+            "micromatch": "^3.1.10"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
+          "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
+    "relay-runtime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-6.0.0.tgz",
+      "integrity": "sha512-zIXQqFfe0zBCVzKbMGEPMvKFxfbE3pY2RbZsKBvHAr/vMDj6OX9E+f4R4udE5xvMbI7g+baYFHi2I9NDEydGaQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "fbjs": "^1.0.0"
+      }
+    },
+    "remedial": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
+      "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "remove-trailing-spaces": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/remove-trailing-spaces/-/remove-trailing-spaces-1.0.7.tgz",
+      "integrity": "sha512-wjM17CJ2kk0SgoGyJ7ZMzRRCuTq+V8YhMwpZ5XEWX0uaked2OUq6utvHXGNBQrfkUzUUABFMyxlKn+85hMv4dg==",
+      "dev": true
     },
     "renderkid": {
       "version": "2.0.3",
@@ -10240,6 +12041,12 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rewrite-imports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/rewrite-imports/-/rewrite-imports-2.0.3.tgz",
@@ -10280,6 +12087,12 @@
       "requires": {
         "is-promise": "^2.1.0"
       }
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -10428,6 +12241,16 @@
         }
       }
     },
+    "sentence-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-2.1.1.tgz",
+      "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case-first": "^1.1.2"
+      }
+    },
     "serialize-javascript": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.0.tgz",
@@ -10535,6 +12358,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "signedsource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/signedsource/-/signedsource-1.0.0.tgz",
+      "integrity": "sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=",
+      "dev": true
+    },
+    "simple-git": {
+      "version": "1.126.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.126.0.tgz",
+      "integrity": "sha512-47mqHxgZnN8XRa9HbpWprzUv3Ooqz9RY/LSZgvA7jCkW8jcwLahMz7LKugY91KZehfG0sCVPtgXiU72hd6b1Bw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.0.1"
+      }
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -10550,6 +12388,12 @@
         }
       }
     },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -10559,6 +12403,15 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snake-case": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-2.1.0.tgz",
+      "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "snapdragon": {
@@ -11027,6 +12880,12 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -11113,6 +12972,22 @@
         "unquote": "~1.1.1",
         "util.promisify": "~1.0.0"
       }
+    },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "dev": true
     },
     "table": {
       "version": "5.4.6",
@@ -11337,6 +13212,16 @@
         "globrex": "^0.1.1"
       }
     },
+    "title-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-2.1.1.tgz",
+      "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.0.3"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -11441,6 +13326,15 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
+    "ts-invariant": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "ts-loader": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.1.tgz",
@@ -11465,6 +13359,12 @@
           }
         }
       }
+    },
+    "ts-log": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.1.4.tgz",
+      "integrity": "sha512-P1EJSoyV+N3bR/IWFeAqXzKPZwHpnLY6j7j58mAvewHRipo+BQM2Y1f9Y9BjEQznKwgqqZm7H8iuixmssU7tYQ==",
+      "dev": true
     },
     "ts-node": {
       "version": "8.4.1",
@@ -11717,6 +13617,15 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.1"
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -11816,6 +13725,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -12922,6 +14837,12 @@
         "wrap-ansi": "^6.0.0"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
+    },
     "which": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.1.tgz",
@@ -13306,6 +15227,22 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+    },
+    "zen-observable": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==",
+      "dev": true
+    },
+    "zen-observable-ts": {
+      "version": "0.8.20",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz",
+      "integrity": "sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.3",
+        "zen-observable": "^0.8.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "nuxt-ts start",
     "generate": "nuxt-ts generate",
     "generate-graphql-types": "graphql-codegen",
-    "lint": "eslint --ext .ts,.js,.vue --ignore-path .gitignore ."
+    "lint": "eslint --ext .ts,.js,.vue ."
   },
   "dependencies": {
     "@nuxt/typescript-runtime": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "nuxt-ts build",
     "start": "nuxt-ts start",
     "generate": "nuxt-ts generate",
+    "generate-graphql-types": "graphql-codegen",
     "lint": "eslint --ext .ts,.js,.vue --ignore-path .gitignore ."
   },
   "dependencies": {
@@ -20,6 +21,8 @@
     "vue-class-component": "^7.1.0"
   },
   "devDependencies": {
+    "@graphql-codegen/cli": "^1.8.3",
+    "@graphql-codegen/typescript": "^1.8.3",
     "@nuxt/typescript-build": "^0.3.4",
     "@nuxtjs/eslint-config-typescript": "^0.1.3",
     "@nuxtjs/eslint-module": "^1.0.0",
@@ -32,6 +35,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-nuxt": ">=0.4.2",
     "eslint-plugin-vue": "^5.2.3",
+    "graphql": "^14.5.8",
     "node-sass": "^4.13.0",
     "sass-loader": "^8.0.0",
     "typescript": "^3.7.2"


### PR DESCRIPTION
Add graphql-codegen to dependencies, and a config for it (the same as used by [js-buy-sdk](/Shopify/js-buy-sdk/)), as well as the types generated by it.